### PR TITLE
test: add xdist support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+# Function scoped isolation fixture to enable xdist.
+# Snapshots the chain before each test and reverts after test completion.
+@pytest.fixture(scope="function", autouse=True)
+def shared_setup(fn_isolation):
+    pass


### PR DESCRIPTION
@fubuloubu this adds support so you can use xdist running locally. Reduces time from 02:47 to 01:59 on my machine.

For other reviewers, please run using `brownie test tests/functional -s -n auto`.

If you want to run the entire tests folder I recommend doing a serial run (e.g. `brownie test -s`), as there's an issue (at least in my environment) with `tests/integration/test_operation.py` and `tests/functional/strategy/test_shutdown.test_emergency_shutdown` interfering causing a read timeout for `test_emergency_shutdown`.