### PR TITLE
Remove governance state from Strategy and use Vault governance for assertions

### DIFF
--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -10,7 +10,7 @@ import {BaseStrategy, StrategyParams} from "../BaseStrategy.sol";
  */
 
 contract TestStrategy is BaseStrategy {
-    constructor(address _vault, address _governance) public BaseStrategy(_vault, _governance) {}
+    constructor(address _vault) public BaseStrategy(_vault) {}
 
     // When exiting the position, wait this many times to give everything back
     uint256 countdownTimer = 3;

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -45,7 +45,7 @@ def keeper(accounts):
 
 @pytest.fixture
 def strategy(gov, strategist, keeper, token, vault, TestStrategy):
-    strategy = strategist.deploy(TestStrategy, vault, gov)
+    strategy = strategist.deploy(TestStrategy, vault)
     strategy.setKeeper(keeper, {"from": strategist})
     vault.addStrategy(
         strategy,

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -1,10 +1,9 @@
 import brownie
 
 
-def test_strategy_deployment(strategist, gov, vault, TestStrategy):
-    strategy = strategist.deploy(TestStrategy, vault, gov)
+def test_strategy_deployment(strategist, vault, TestStrategy):
+    strategy = strategist.deploy(TestStrategy, vault)
     # Addresses
-    assert strategy.governance() == gov
     assert strategy.strategist() == strategist
     assert strategy.keeper() == strategist
     assert strategy.want() == vault.token()
@@ -61,25 +60,3 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
 
     strategy.setEmergencyExit({"from": strategist})
     assert strategy.emergencyExit()
-
-
-def test_strategy_setGovernance(strategy, gov, rando):
-    newGov = rando
-    # No one can set governance but governance
-    with brownie.reverts():
-        strategy.setGovernance(newGov, {"from": newGov})
-    # Governance doesn't change until it's accepted
-    strategy.setGovernance(newGov, {"from": gov})
-    assert strategy.governance() == gov
-    # Only new governance can accept a change of governance
-    with brownie.reverts():
-        strategy.acceptGovernance({"from": gov})
-    # Governance doesn't change until it's accepted
-    strategy.acceptGovernance({"from": newGov})
-    assert strategy.governance() == newGov
-    # No one can set governance but governance
-    with brownie.reverts():
-        strategy.setGovernance(newGov, {"from": gov})
-    # Only new governance can accept a change of governance
-    with brownie.reverts():
-        strategy.acceptGovernance({"from": gov})

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -12,7 +12,7 @@ def test_good_migration(
     assert strategy_debt > 0
     assert prior_position > 0
 
-    new_strategy = strategist.deploy(TestStrategy, vault, gov)
+    new_strategy = strategist.deploy(TestStrategy, vault)
     assert vault.strategies(new_strategy)[4] == 0
     assert token.balanceOf(new_strategy) == 0
 
@@ -37,13 +37,13 @@ def test_bad_migration(
     token, vault, strategy, gov, strategist, TestStrategy, Vault, rando
 ):
     different_vault = gov.deploy(Vault, token, gov, gov, "", "")
-    new_strategy = strategist.deploy(TestStrategy, different_vault, gov)
+    new_strategy = strategist.deploy(TestStrategy, different_vault)
 
     # Can't migrate to a strategy with a different vault
     with brownie.reverts():
         vault.migrateStrategy(strategy, new_strategy, {"from": gov})
 
-    new_strategy = strategist.deploy(TestStrategy, vault, gov)
+    new_strategy = strategist.deploy(TestStrategy, vault)
 
     # Can't migrate if you're not the Vault  or governance
     with brownie.reverts():

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -26,7 +26,7 @@ def test_harvest_tend_authority(gov, keeper, strategist, strategy, rando):
 
 
 def test_harvest_tend_trigger(gov, vault, token, TestStrategy):
-    strategy = gov.deploy(TestStrategy, vault, gov)
+    strategy = gov.deploy(TestStrategy, vault)
     assert not strategy.harvestTrigger(0)
 
     vault.addStrategy(strategy, 10 ** 18, 1000, 50, {"from": gov})
@@ -81,8 +81,6 @@ def test_sweep(gov, strategy, rando, token, other_token):
 def test_reject_ether(gov, strategy):
     # These functions should reject any calls with value
     for func, args in [
-        ("setGovernance", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
-        ("acceptGovernance", []),
         ("setStrategist", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
         ("setKeeper", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
         ("tend", []),

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -11,7 +11,7 @@ def vault(gov, token, Vault):
 @pytest.fixture
 def strategy(gov, vault, TestStrategy):
     # NOTE: Because the fixture has tokens in it already
-    yield gov.deploy(TestStrategy, vault, gov)
+    yield gov.deploy(TestStrategy, vault)
 
 
 def test_addStrategy(web3, gov, vault, strategy, rando):
@@ -72,7 +72,7 @@ def test_migrateStrategy(gov, vault, strategy, rando, TestStrategy):
 
     # Migrating not in the withdrawal queue (for coverage)
     vault.removeStrategyFromQueue(strategy, {"from": gov})
-    new_strategy = gov.deploy(TestStrategy, vault, gov)
+    new_strategy = gov.deploy(TestStrategy, vault)
     vault.migrateStrategy(strategy, new_strategy, {"from": gov})
 
     # Can migrate back again (but it starts out fresh)
@@ -83,7 +83,7 @@ def test_migrateStrategy(gov, vault, strategy, rando, TestStrategy):
         vault.migrateStrategy(new_strategy, strategy, {"from": gov})
 
     # Can't migrate to an already approved strategy
-    approved_strategy = gov.deploy(TestStrategy, vault, gov)
+    approved_strategy = gov.deploy(TestStrategy, vault)
     vault.addStrategy(approved_strategy, 1000, 10, 50, {"from": gov})
     with brownie.reverts():
         vault.migrateStrategy(strategy, approved_strategy, {"from": gov})
@@ -118,7 +118,7 @@ def test_revokeStrategy(web3, gov, vault, strategy, rando):
 
 def test_ordering(gov, vault, TestStrategy, rando):
     # Show that a lot of strategies get properly ordered
-    strategies = [gov.deploy(TestStrategy, vault, gov) for _ in range(19)]
+    strategies = [gov.deploy(TestStrategy, vault) for _ in range(19)]
     [vault.addStrategy(s, 1000, 10, 50, {"from": gov}) for s in strategies]
 
     for idx, strategy in enumerate(strategies):
@@ -143,7 +143,7 @@ def test_ordering(gov, vault, TestStrategy, rando):
         assert vault.withdrawalQueue(idx) == strategy
 
     # Show that adding a new one properly orders
-    strategy = gov.deploy(TestStrategy, vault, gov)
+    strategy = gov.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 1000, 10, 50, {"from": gov})
     strategies.append(strategy)
 
@@ -152,9 +152,7 @@ def test_ordering(gov, vault, TestStrategy, rando):
 
     # NOTE: limited to only a certain amount of strategies
     with brownie.reverts():
-        vault.addStrategy(
-            gov.deploy(TestStrategy, vault, gov), 1000, 10, 50, {"from": gov}
-        )
+        vault.addStrategy(gov.deploy(TestStrategy, vault), 1000, 10, 50, {"from": gov})
 
     # Show that removing from the middle properly orders
     strategy = strategies.pop(1)

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -1,5 +1,5 @@
 def test_multiple_withdrawals(token, gov, vault, TestStrategy):
-    strategies = [gov.deploy(TestStrategy, vault, gov) for _ in range(5)]
+    strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
     [vault.addStrategy(s, 1000, 10, 50, {"from": gov}) for s in strategies]
 
     before_balance = token.balanceOf(gov)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,7 +50,7 @@ def keeper(accounts):
 
 @pytest.fixture
 def strategy(gov, strategist, keeper, vault, TestStrategy):
-    strategy = strategist.deploy(TestStrategy, vault, gov)
+    strategy = strategist.deploy(TestStrategy, vault)
     strategy.setKeeper(keeper)
     yield strategy
 


### PR DESCRIPTION
The governance state on the Vault is authoritive for the Strategy, so this PR:

- Removes governance state variables/functions from the Strategy
- Adds an `governance() internal view` function to the Strategy for internal governance address resolution
- Asserts protected functions against this `governance()` function
- Updates tests with new constructor args (no more gov)
- Removes tests for set/acceptGovernance