### PR TITLE
feat: added test to check user not withdrawing more than what they have

### DIFF
--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -38,7 +38,7 @@ def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
     [vault.addStrategy(s, 1000, 10, 50, {"from": gov}) for s in strategies]
 
-    # Send tokens to the rando user
+    # Send tokens to random user
     token.approve(gov, 2 ** 256 - 1, {"from": gov})
     token.transferFrom(gov, rando, 1000, {"from": gov})
     assert token.balanceOf(rando) == 1000


### PR DESCRIPTION
I thought there was a bug so I created a test. The code works correctly but because of an exception in the VM.

Exception:

```
>       vault.withdraw(Wei("110 ether"), {"from": rando})
E       brownie.exceptions.VirtualMachineError: revert: Integer underflow
E       Trace step -1, program counter 4703:
E         File "contracts/Vault.vy", line 418, in Vault.withdraw:    
E       
E           # Burn shares (full value of what was withdrawn)
E           self.totalSupply -= shares
E           self.balanceOf[msg.sender] -= shares
E           log Transfer(msg.sender, ZERO_ADDRESS, shares)
E       
E           # Withdraw remaining balance (minus fee)

tests/functional/vault/test_withdrawal.py:63: VirtualMachineError
```
Shouldn't we add an assert at the beginning of `withdraw()` to make sure the user has enough funds?
