### PR TITLE
Add Strategy and Vault Yield Oracles

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -14,6 +14,8 @@ struct StrategyParams {
     uint256 totalDebt;
     uint256 totalGain;
     uint256 totalLoss;
+    uint256 apy12dEMA; // Actually fixed168x10, but no Solidity support (`x / 1e10` to use)
+    uint256 apy50dEMA; // Actually fixed168x10, but no Solidity support (`x / 1e10` to use)
 }
 
 interface VaultAPI is IERC20 {

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -97,6 +97,8 @@ struct StrategyParams:
     totalDebt: uint256  # Total outstanding debt that Strategy has
     totalGain: uint256  # Total returns that Strategy has realized for Vault
     totalLoss: uint256  # Total losses that Strategy has realized for Vault
+    apy12dEMA: decimal  # Annual percentage yield (12d EMA)
+    apy50dEMA: decimal  # Annual percentage yield (50d EMA)
 
 
 event StrategyAdded:
@@ -211,6 +213,8 @@ debtRatio: public(uint256)  # Debt ratio for the Vault across all strategies (in
 totalDebt: public(uint256)  # Amount of tokens that all strategies have borrowed
 lastReport: public(uint256)  # block.timestamp of last report
 activation: public(uint256)  # block.timestamp of contract deployment
+apy12dEMA: public(decimal)  # Annual percentage yield (12d EMA)
+apy50dEMA: public(decimal)  # Annual percentage yield (50d EMA)
 
 rewards: public(address)  # Rewards contract where Governance fees are sent to
 # Governance Fee for management of Vault (given to `rewards`)
@@ -1044,6 +1048,8 @@ def addStrategy(
         totalDebt: 0,
         totalGain: 0,
         totalLoss: 0,
+        apy12dEMA: 0.0,
+        apy50dEMA: 0.0,
     })
     self.debtRatio += debtRatio
     log StrategyAdded(strategy, debtRatio, rateLimit, performanceFee)
@@ -1163,6 +1169,8 @@ def migrateStrategy(oldVersion: address, newVersion: address):
         totalDebt: strategy.totalDebt,
         totalGain: 0,
         totalLoss: 0,
+        apy12dEMA: 0.0,
+        apy50dEMA: 0.0,
     })
 
     Strategy(oldVersion).migrate(newVersion)
@@ -1427,6 +1435,18 @@ def _assessFees(strategy: address, gain: uint256):
             self._transfer(self, self.rewards, self.balanceOf[self])
 
 
+@pure
+@internal
+def _computeEMA(
+    _currentReading: decimal,
+    _previousReading: decimal,
+    _observationPeriodLength: decimal,
+) -> decimal:
+    # measure the N-day EMA of the strategy's return
+    smoothingFactor: decimal = 2.0 / (_observationPeriodLength + 1.0)
+    return _previousReading + smoothingFactor * (_currentReading - _previousReading)
+
+
 @external
 def report(gain: uint256, loss: uint256, _debtPayment: uint256) -> uint256:
     """
@@ -1473,6 +1493,11 @@ def report(gain: uint256, loss: uint256, _debtPayment: uint256) -> uint256:
     # Assess both management fee and performance fee, and issue both as shares of the vault
     self._assessFees(msg.sender, gain)
 
+    # Use this for APY metrics
+    # NOTE: Need this now before any adjustments occur
+    prevDebt: decimal = convert(self.strategies[msg.sender].totalDebt, decimal)
+    prevTotalDebt: decimal = convert(self.totalDebt, decimal)
+
     # Returns are always "realized gains"
     self.strategies[msg.sender].totalGain += gain
 
@@ -1509,6 +1534,47 @@ def report(gain: uint256, loss: uint256, _debtPayment: uint256) -> uint256:
     elif totalAvail > credit:  # credit deficit, take from Strategy
         assert self.token.transferFrom(msg.sender, self, totalAvail - credit)
     # else, don't do anything because it is balanced
+
+    # NOTE: This is after returns are bookkept, but before reporting time is updated
+    realizedReturn: decimal = convert(self._expectedReturn(msg.sender), decimal)
+    # Adjust by estimated number of harvests per year
+    realizedReturn *= (
+        convert(SECS_PER_YEAR, decimal)
+        / convert(block.timestamp - self.strategies[msg.sender].lastReport, decimal)
+    )
+    # Normalize to total debt (using debt from the period the return was generated)
+    if prevDebt != 0.0:
+        realizedReturn /= prevDebt
+    else:
+        realizedReturn = 0.0
+    prev_apy12dEMA: decimal = self.strategies[msg.sender].apy12dEMA
+    prev_apy50dEMA: decimal = self.strategies[msg.sender].apy50dEMA
+    nextDebt: decimal = convert(self.strategies[msg.sender].totalDebt, decimal)
+    nextTotalDebt: decimal = convert(self.totalDebt, decimal)
+
+    # Update Strategy Metrics
+    # NOTE: Block delta can't ever be 0
+    next_apy12dEMA: decimal = self._computeEMA(
+        realizedReturn,
+        prev_apy12dEMA,
+        12.0,
+    )
+    next_apy50dEMA: decimal = self._computeEMA(
+        realizedReturn,
+        prev_apy50dEMA,
+        50.0,
+    )
+    self.strategies[msg.sender].apy12dEMA = next_apy12dEMA
+    self.strategies[msg.sender].apy50dEMA = next_apy50dEMA
+
+    # Updated debt-weight total Vault Metrics
+    # NOTE: Adjusts a ratio by a ratio, should not revert as long as totalDebt < 1e38
+    if nextTotalDebt != 0.0:
+        self.apy12dEMA += next_apy12dEMA * (nextDebt / nextTotalDebt)
+        self.apy50dEMA += next_apy50dEMA * (nextDebt / nextTotalDebt)
+    if prevTotalDebt != 0.0:
+        self.apy12dEMA -= prev_apy12dEMA * (prevDebt / prevTotalDebt)
+        self.apy50dEMA -= prev_apy50dEMA * (prevDebt / prevTotalDebt)
 
     # Update reporting time
     self.strategies[msg.sender].lastReport = block.timestamp

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -7,4 +7,8 @@ contract Token is ERC20 {
     constructor() public ERC20("yearn.finance test token", "TEST") {
         _mint(msg.sender, 30000 * 10**18);
     }
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
 }

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -4,7 +4,7 @@ import brownie
 FEE_MAX = 10_000
 
 
-def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
+def test_performance_fees(chain, gov, vault, token, TestStrategy, rewards, strategist):
     vault.setManagementFee(0, {"from": gov})
     vault.setPerformanceFee(450, {"from": gov})
 
@@ -14,13 +14,14 @@ def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     strategy = strategist.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 2_000, 1000, 50, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": strategist})
 
     assert vault.balanceOf(rewards) == 0.045 * 1e8
     assert vault.balanceOf(strategist) == 0.005 * 1e8
 
 
-def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
+def test_zero_fees(chain, gov, vault, token, TestStrategy, rewards, strategist):
     vault.setManagementFee(0, {"from": gov})
     vault.setPerformanceFee(0, {"from": gov})
 
@@ -30,6 +31,7 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     strategy = strategist.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": strategist})
 
     assert vault.managementFee() == 0

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -4,9 +4,10 @@ from brownie import ZERO_ADDRESS
 
 
 def test_good_migration(
-    token, strategy, vault, gov, strategist, guardian, TestStrategy, rando
+    chain, token, strategy, vault, gov, strategist, guardian, TestStrategy, rando
 ):
     # Call this once to seed the strategy with debt
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": strategist})
 
     strategy_debt = vault.strategies(strategy).dict()["totalDebt"]

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -2,7 +2,7 @@ import pytest
 import brownie
 
 
-def test_harvest_tend_authority(gov, keeper, strategist, strategy, rando):
+def test_harvest_tend_authority(chain, gov, keeper, strategist, strategy, rando):
     # Only keeper, strategist, or gov can call tend
     strategy.tend({"from": keeper})
     strategy.tend({"from": strategist})
@@ -11,9 +11,13 @@ def test_harvest_tend_authority(gov, keeper, strategist, strategy, rando):
         strategy.tend({"from": rando})
 
     # Only keeper, strategist, or gov can call harvest
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": keeper})
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": strategist})
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": gov})
+    chain.sleep(1)  # Reverts if no delta time
     with brownie.reverts():
         strategy.harvest({"from": rando})
 
@@ -48,6 +52,7 @@ def test_harvest_tend_trigger(chain, gov, vault, token, TestStrategy):
 
     # Stops after it runs out of balance
     while strategy.harvestTrigger(0):
+        chain.sleep(1)  # Reverts if no delta time
         strategy.harvest({"from": gov})
 
     assert strategy.estimatedTotalAssets() == 0

--- a/tests/functional/strategy/test_rate_limit.py
+++ b/tests/functional/strategy/test_rate_limit.py
@@ -34,5 +34,6 @@ def test_zero_limit(gov, vault, token, TestStrategy):
     vault.addStrategy(strategy, 2_000, 0, 0, {"from": gov})
 
     assert token.balanceOf(strategy) == 0
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": gov})
     assert token.balanceOf(strategy) == vault.totalAssets() // 5

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -5,6 +5,7 @@ def test_emergency_shutdown(token, gov, vault, strategy, keeper, chain):
     # NOTE: totalSupply matches total investment at t = 0
     initial_investment = vault.totalSupply()
     # Do it once to seed it with debt
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": keeper})
     add_yield = lambda: token.transfer(
         strategy, token.balanceOf(strategy) // 50, {"from": gov}
@@ -43,6 +44,7 @@ def test_emergency_shutdown(token, gov, vault, strategy, keeper, chain):
 
     # Do it once more, for good luck (and also coverage)
     token.transfer(strategy, token.balanceOf(gov), {"from": gov})
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": keeper})
 
     # Vault didn't lose anything during shutdown
@@ -55,6 +57,7 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain):
     # NOTE: totalSupply matches total investment at t = 0
     initial_investment = vault.totalSupply()
     # Do it once to seed it with debt
+    chain.sleep(1)  # Reverts if no delta time
     strategy.harvest({"from": keeper})
     add_yield = lambda: token.transfer(
         strategy, token.balanceOf(strategy) // 50, {"from": gov}

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -61,6 +61,8 @@ def test_addStrategy(
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
 
     vault.addStrategy(strategy, 100, 10, 1000, {"from": gov})
@@ -74,6 +76,8 @@ def test_addStrategy(
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
     assert vault.withdrawalQueue(0) == strategy
 
@@ -124,6 +128,8 @@ def test_updateStrategy(chain, gov, vault, strategy, rando):
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
 
     vault.updateStrategyRateLimit(strategy, 15, {"from": gov})
@@ -136,6 +142,8 @@ def test_updateStrategy(chain, gov, vault, strategy, rando):
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
 
     vault.updateStrategyPerformanceFee(strategy, 75, {"from": gov})
@@ -148,6 +156,8 @@ def test_updateStrategy(chain, gov, vault, strategy, rando):
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
 
 
@@ -200,6 +210,8 @@ def test_revokeStrategy(chain, gov, vault, strategy, rando):
         "totalGain": 0,
         "totalLoss": 0,
         "totalDebt": 0,
+        "apy12dEMA": "0.0",
+        "apy50dEMA": "0.0",
     }
 
     assert vault.withdrawalQueue(0) == strategy

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,11 +96,9 @@ def new_strategy(chain, gov, strategist, keeper, vault, TestStrategy):
         if seed_debt:
             mgmt_fee = vault.managementFee()
             vault.setManagementFee(0, {"from": gov})
-            blocks_to_wait = math.ceil(
-                vault.strategies(strategy)[2] / vault.strategies(strategy)[3]
-            )
-            assert blocks_to_wait < 50, "Set the rate limit lower!"
-            chain.mine(blocks_to_wait)  # Should be at least 1
+            params = vault.strategies(strategy).dict()
+            secs_to_wait = math.ceil(debt_limit / rate_limit)
+            chain.sleep(secs_to_wait)  # Should be at least 1
             strategy.harvest({"from": keeper})  # Seed strategy up with debt
             vault.setManagementFee(mgmt_fee, {"from": gov})
         return strategy

--- a/tests/integration/test_calculation.py
+++ b/tests/integration/test_calculation.py
@@ -1,0 +1,86 @@
+PRECISION = 0.01  # 1%
+
+
+def tolerance(expected, real):
+    return abs(expected - real) / real
+
+
+def test_calculations(chain, token, vault, new_strategy, andre, keeper, whale):
+    whale  # NOTE: Without importing this, there is no deposits in vault
+    total = token.balanceOf(vault)
+
+    strategies = []
+    # 1/6 + 1/3 + 1/2 = 1
+    strategies.append(new_strategy(debt_limit=total // 6, perf_fee=65, seed_debt=True))
+    strategies.append(new_strategy(debt_limit=total // 3, perf_fee=50, seed_debt=True))
+    strategies.append(new_strategy(debt_limit=total // 2, perf_fee=35, seed_debt=True))
+
+    # Each strategy's debt limits ratios
+    debt_ratios = tuple(vault.strategies(s)[2] / vault.debtLimit() for s in strategies)
+
+    # Each strategy's expected returns (actually used to realize returns in test)
+    rates = (0.0003, 0.0005, 0.0007)
+
+    # Each strategy's combined governance + strategist performance fee (adjusted from bps)
+    perf_fees = tuple(
+        (vault.strategies(s)[0] + vault.performanceFee()) / 10_000 for s in strategies
+    )
+
+    # The total expected yearly apy for the Vault (debt-weighted sum)
+    vault_apy = sum(
+        dr * (365 * r - pf) for dr, r, pf in zip(debt_ratios, rates, perf_fees)
+    )
+
+    # Don't forget to account for the management fee! (adjusted from bps)
+    vault_apy -= vault.managementFee() / 10_000
+
+    # NOTE: Raw is about 20% APY, fee total shaves about 6%
+    assert tolerance(vault_apy, 0.13733) < PRECISION
+
+    for day in range(1, 365 + 1):  # 1 harvest a day for each strat, over 1 year
+        for strategy, rate in zip(strategies, rates):
+            # 3 strategies, harvested once per day (6300 blocks) at equal intervals
+            chain.mine(2100, timestamp=chain.time() + 8 * 60 * 60)
+
+            # Simulate "earning" a yield
+            expected_return = vault.expectedReturn(strategy)
+            realized_return = rate * token.balanceOf(strategy)
+            token.mint(strategy, realized_return, {"from": andre})
+            strategy.harvest({"from": keeper})
+
+            # Measure Strategy returns
+            blocknum = len(chain)
+            realized_return = realized_return / 10 ** vault.decimals()
+            expected_return = expected_return / 10 ** vault.decimals()
+            apy_12d_ema, apy_50d_ema = vault.strategies(strategy)[-2:]
+
+            print(f"[d{day:03d}-b{blocknum:07d}]   Strat: {strategy.address}")
+            print(f"[d{day:03d}-b{blocknum:07d}]  Return: {realized_return}")
+            print(f"[d{day:03d}-b{blocknum:07d}]    E[R]: {expected_return}")
+            print(f"[d{day:03d}-b{blocknum:07d}] 12d EMA: {apy_12d_ema}")
+            print(f"[d{day:03d}-b{blocknum:07d}] 50d EMA: {apy_50d_ema}")
+
+            if day > 12:
+                assert tolerance(float(apy_12d_ema), realized_return) < PRECISION
+            if day > 50:
+                assert tolerance(float(apy_50d_ema), realized_return) < PRECISION
+
+        # Measure Vaults returns
+        blocknum = len(chain)
+        share_price = vault.pricePerShare() / 10 ** vault.decimals()
+        expected_price = 1 + vault_apy * day / 365
+        apy_12d_ema = vault.apy12dEMA()
+        apy_50d_ema = vault.apy50dEMA()
+
+        print(f"[d{day:03d}-b{blocknum:07d}]   Vault: {vault.address}")
+        print(f"[d{day:03d}-b{blocknum:07d}]   Price: {share_price}")
+        print(f"[d{day:03d}-b{blocknum:07d}]    E[P]: {expected_price}")
+        print(f"[d{day:03d}-b{blocknum:07d}] 12d EMA: {apy_12d_ema}")
+        print(f"[d{day:03d}-b{blocknum:07d}] 50d EMA: {apy_50d_ema}")
+
+        if day > 3:
+            assert tolerance(share_price, expected_price) < PRECISION
+        if day > 12:
+            assert tolerance(float(apy_12d_ema), vault_apy) < PRECISION
+        if day > 50:
+            assert tolerance(float(apy_50d_ema), vault_apy) < PRECISION

--- a/tests/integration/test_operation.py
+++ b/tests/integration/test_operation.py
@@ -1,5 +1,6 @@
 class NormalOperation:
-    def __init__(self, web3, token, vault, strategy, user, farm, keeper):
+    def __init__(self, chain, web3, token, vault, strategy, user, farm, keeper):
+        self.chain = chain
         self.web3 = web3
         self.token = token
         self.vault = vault
@@ -30,6 +31,7 @@ class NormalOperation:
         self.token.transfer(self.strategy, amt, {"from": self.farm})
 
         # Keeper decides to harvest the yield
+        self.chain.sleep(1)
         self.strategy.harvest({"from": self.keeper})
 
     # TODO: Invariant that user did not get > they should have
@@ -38,8 +40,10 @@ class NormalOperation:
 
 
 def test_normal_operation(
-    web3, new_strategy, vault, token, chad, andre, keeper, state_machine
+    chain, web3, new_strategy, vault, token, chad, andre, keeper, state_machine
 ):
     strategy = new_strategy(debt_ratio=1.0, seed_debt=True)
     assert token.balanceOf(vault) == 0
-    state_machine(NormalOperation, web3, token, vault, strategy, chad, andre, keeper)
+    state_machine(
+        NormalOperation, chain, web3, token, vault, strategy, chad, andre, keeper
+    )

--- a/tests/integration/test_operation.py
+++ b/tests/integration/test_operation.py
@@ -38,16 +38,8 @@ class NormalOperation:
 
 
 def test_normal_operation(
-    web3, chain, gov, strategy, vault, token, chad, andre, keeper, state_machine
+    web3, new_strategy, vault, token, chad, andre, keeper, state_machine
 ):
-    vault.addStrategy(
-        strategy,
-        10_000,  # 100% of Vault AUM
-        2 ** 256 - 1,  # no rate limit
-        1000,  # 10% performance fee for Strategist
-        {"from": gov},
-    )
-    chain.sleep(1)
-    strategy.harvest({"from": keeper})
+    strategy = new_strategy(debt_ratio=1.0, seed_debt=True)
     assert token.balanceOf(vault) == 0
     state_machine(NormalOperation, web3, token, vault, strategy, chad, andre, keeper)


### PR DESCRIPTION
This feature adds two new parameters to all connected Strategies: 12-day and 50-day EMAs of the Strategy's annual returns

It also adds a debt-weighted sum of the Vault's overall annual return, using the 12-day and 50-day EMAs of all connected Strategies

It isn't known how well these will perform in practice. However, tests were added that ensures it should not generate any unexpected issues. Further experimentation is required.

TODO:
- [ ] Add functional tests
- [x] Add integration tests