### PR TITLE
fix: use proper contract for non-compliant ERC20 testing

### DIFF
--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -25,7 +25,7 @@ contract TestStrategy is BaseStrategyInitializable {
 
     // NOTE: This is a test-only function to simulate losses
     function _takeFunds(uint256 amount) public {
-        want.transfer(msg.sender, amount);
+        want.safeTransfer(msg.sender, amount);
     }
 
     // NOTE: This is a test-only function to enable reentrancy on withdraw

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.6.12;
 
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Token is ERC20 {
@@ -23,20 +24,57 @@ contract Token is ERC20 {
         require(!_blocked[to], "Token transfer refused. Receiver is on blacklist");
         super._beforeTokenTransfer(from, to, amount);
     }
+}
 
-    function transferWithoutReturn(address recipient, uint256 amount) public {
-        super.transfer(recipient, amount);
+contract TokenNoReturn {
+    using SafeMath for uint256;
+
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    mapping(address => bool) public _blocked;
+
+    constructor(uint8 _decimals) public {
+        name = "yearn.finance test token";
+        symbol = "TEST";
+        decimals = _decimals;
+        balanceOf[msg.sender] = 30000 * 10**uint256(_decimals);
+        totalSupply = 30000 * 10**uint256(_decimals);
     }
 
-    function transferFromWithoutReturn(
+    function _setBlocked(address user, bool value) public virtual {
+        _blocked[user] = value;
+    }
+
+    function transfer(address receiver, uint256 amount) external {
+        require(!_blocked[receiver], "Token transfer refused. Receiver is on blacklist");
+        balanceOf[msg.sender] = balanceOf[msg.sender].sub(amount);
+        balanceOf[receiver] = balanceOf[receiver].add(amount);
+        emit Transfer(msg.sender, receiver, amount);
+    }
+
+    function approve(address spender, uint256 amount) external {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+    }
+
+    function transferFrom(
         address sender,
-        address recipient,
+        address receiver,
         uint256 amount
-    ) public {
-        super.transferFrom(sender, recipient, amount);
-    }
-
-    function approveWithoutReturn(address spender, uint256 amount) public {
-        super.approve(spender, amount);
+    ) external {
+        require(!_blocked[receiver], "Token transfer refused. Receiver is on blacklist");
+        allowance[sender][msg.sender] = allowance[sender][msg.sender].sub(amount);
+        balanceOf[sender] = balanceOf[sender].sub(amount);
+        balanceOf[receiver] = balanceOf[receiver].add(amount);
+        emit Transfer(sender, receiver, amount);
     }
 }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from brownie import Token, TokenNoReturn
+
 
 @pytest.fixture
 def gov(accounts):
@@ -22,18 +24,11 @@ def management(accounts):
 
 
 @pytest.fixture(params=[("Normal", 18), ("NoReturn", 18), ("Normal", 8), ("Normal", 2)])
-def token(gov, Token, request):
+def token(gov, request):
     (behaviour, decimal) = request.param
 
-    token = gov.deploy(Token, decimal)
     # NOTE: Run our test suite using both compliant and non-compliant ERC20 Token
-    if behaviour == "NoReturn":
-        token._initialized = False  # otherwise Brownie throws an `AttributeError`
-        setattr(token, "transfer", token.transferWithoutReturn)
-        setattr(token, "transferFrom", token.transferFromWithoutReturn)
-        setattr(token, "approve", token.approveWithoutReturn)
-        token._initialized = True  # shhh, nothing to see here...
-    yield token
+    yield gov.deploy(Token if behaviour == "Normal" else TokenNoReturn, decimal)
 
 
 @pytest.fixture


### PR DESCRIPTION
Previous testing did not actually perform the mechanics that non-compliant tokens like Tether have.