### PR TITLE
chore: upgrade to vyper v0.2.11

### DIFF
--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -1,4 +1,4 @@
-# @version 0.2.8
+# @version 0.2.11
 
 
 interface Vault:

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1,4 +1,4 @@
-# @version 0.2.8
+# @version 0.2.11
 """
 @title Yearn Token Vault
 @license GNU AGPLv3

--- a/tests/functional/vault/test_misc.py
+++ b/tests/functional/vault/test_misc.py
@@ -206,12 +206,12 @@ def test_reject_ether(gov, vault):
         ("sweep", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
         ("sweep", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1]),
     ]:
-        with brownie.reverts("Cannot send ether to nonpayable function"):
+        with brownie.reverts():
             # NOTE: gov can do anything
             getattr(vault, func)(*args, {"from": gov, "value": 1})
 
     # Fallback fails too
-    with brownie.reverts("Cannot send ether to nonpayable function"):
+    with brownie.reverts():
         gov.transfer(vault, 1)
 
     # NOTE: Just for coverage


### PR DESCRIPTION
fixes: #189

Note: the v0.2.11 release contains an internal upgrade to Vyper such that EIP-1167 forwarder-style proxies are now the default for `create_forwarder_to`, among some other minor improvements to gas costs and bytecode size.