### PR TITLE
refactor: standardize terminology for vaults in registry

### DIFF
--- a/contracts/BaseWrapper.sol
+++ b/contracts/BaseWrapper.sol
@@ -14,7 +14,7 @@ interface RegistryAPI {
 
     function latestVault(address token) external view returns (address);
 
-    function nextDeployment(address token) external view returns (uint256);
+    function numVaults(address token) external view returns (uint256);
 
     function vaults(address token, uint256 deploymentId) external view returns (address);
 }
@@ -49,21 +49,21 @@ abstract contract BaseWrapper {
 
     function allVaults() public virtual view returns (VaultAPI[] memory) {
         uint256 cache_length = _cachedVaults.length;
-        uint256 num_deployments = registry.nextDeployment(address(token));
+        uint256 num_vaults = registry.numVaults(address(token));
 
         // Use cached
-        if (cache_length == num_deployments) {
+        if (cache_length == num_vaults) {
             return _cachedVaults;
         }
 
-        VaultAPI[] memory vaults = new VaultAPI[](num_deployments);
+        VaultAPI[] memory vaults = new VaultAPI[](num_vaults);
 
-        for (uint256 deployment_id = 0; deployment_id < cache_length; deployment_id++) {
-            vaults[deployment_id] = _cachedVaults[deployment_id];
+        for (uint256 vault_id = 0; vault_id < cache_length; vault_id++) {
+            vaults[vault_id] = _cachedVaults[vault_id];
         }
 
-        for (uint256 deployment_id = cache_length; deployment_id < num_deployments; deployment_id++) {
-            vaults[deployment_id] = VaultAPI(registry.vaults(address(token), deployment_id));
+        for (uint256 vault_id = cache_length; vault_id < num_vaults; vault_id++) {
+            vaults[vault_id] = VaultAPI(registry.vaults(address(token), vault_id));
         }
 
         return vaults;

--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -4,7 +4,7 @@ import brownie
 
 def test_registry_deployment(gov, registry):
     assert registry.governance() == gov
-    assert registry.nextRelease() == 0
+    assert registry.numReleases() == 0
 
 
 def test_registry_setGovernance(gov, registry, rando):

--- a/tests/functional/wrappers/test_affliate.py
+++ b/tests/functional/wrappers/test_affliate.py
@@ -13,7 +13,7 @@ def test_config(gov, token, vault, registry, affiliate_token):
     assert affiliate_token.decimals() == vault.decimals() == token.decimals()
 
     # No vault added to the registry yet, so these methods should fail
-    assert registry.nextDeployment(token) == 0
+    assert registry.numVaults(token) == 0
 
     with brownie.reverts():
         affiliate_token.bestVault()

--- a/tests/functional/wrappers/test_ytoken.py
+++ b/tests/functional/wrappers/test_ytoken.py
@@ -7,7 +7,7 @@ def test_config(gov, token, vault, registry, ytoken):
     assert ytoken.token() == token
 
     # No vault added to the registry yet, so these methods should fail
-    assert registry.nextDeployment(token) == 0
+    assert registry.numVaults(token) == 0
 
     with brownie.reverts():
         assert ytoken.name()

--- a/tests/integration/test_release.py
+++ b/tests/integration/test_release.py
@@ -44,7 +44,7 @@ class ReleaseTest:
         else:
             self.vaults[token] = [vault]
 
-    def rule_new_deployment(self, new_token="st_bool"):
+    def rule_new_vault(self, new_token="st_bool"):
         tokens_with_stale_deployments = [
             token
             for token, deployments in self.vaults.items()


### PR DESCRIPTION
This would have driven me crazy if we didn't standardize this before redeploying