### PR TITLE
feat: update ops manual on endorsing previous release vaults

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -174,12 +174,12 @@ registry.endorseVault(vault) # from ychad.eth
 
 Or if you are endorsing a vault from previous release:
 
-1. check for latest release number in the registry contract
-2. check the apiVersion of the vault you want to endorse to identify target release
-3. calculate the releaseDelta from your target release. (see registry endorseVault param details)
+1. Check for latest release number in the registry contract
+2. Check the apiVersion of the vault you want to endorse to identify target release
+3. Calculate the releaseDelta from your target release. (see registry endorseVault param details)
    E.g: latestRelease = 0.3.3 and numReleases = 5. New vault apiVersion is 0.3.2
    `releaseDelta = numReleases - 1 - releaseTarget`
-4. confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.
+4. Confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.
 
 ```python
  releaseTarget = 3 # e.g vault api version 0.3.2

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -35,6 +35,7 @@
 - Complete peer review by at least 2 strategists.
 - Check if `want` token has a deployed vault already (>=v0.3.0) and coordinate to use that first if possible.
 - If a new vault is needed, deploy it using the registry:
+
   - Set strategists multisig (`0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7`) as governance.
   - Set Core Dev multisig (`dev.ychad.eth`) as guardian.
   - Set treasury (`treasury.ychad.eth`) as the rewards address.
@@ -162,13 +163,29 @@
   ```
 
 - Yearn governance now must accept governance and endorse the vault:
-
-  ```python
-  strategy.acceptGovernance() # from ychad.eth
-  registry.endorseVault(vault) # from ychad.eth
-  ```
-
   **Note**: Order is important. Will fail if order is wrong.
+
+Endorsing a vault from latest release (use instructions for previous release below) :
+
+```python
+strategy.acceptGovernance() # from ychad.eth
+registry.endorseVault(vault) # from ychad.eth
+```
+
+Or if you are endorsing a vault from previous release:
+
+1. check for latest release number in the registry contract
+2. check the apiVersion of the vault you want to endorse
+3. calculate the releaseDelta to get target release. (see registry endorseVault param details)
+   E.g: latestRelease = 0.3.3 and numReleases = 5. New vault apiVersion is 0.3.2
+   `releaseDelta = self.numReleases - 1 - releaseTarget`
+4. confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.
+
+```python
+ releaseDelta = self.numReleases - 1 - releaseTarget
+ strategy.acceptGovernance() # from ychad.eth
+ registry.endorseVault(vault, releaseDelta) # from ychad.eth.
+```
 
 - Now you are on main yearn page!
 
@@ -185,10 +202,10 @@
 
 These are the standard deposit limits per stage. They can be adjusted on a case by case basis.
 
-| Stage                      | Limit  |
-| -------------------------- | ------ |
-| Experimental               | \$500K |
-| Production                 | \$10M  |
+| Stage        | Limit  |
+| ------------ | ------ |
+| Experimental | \$500K |
+| Production   | \$10M  |
 
 ## Revoking a strategy with normal migration
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -182,7 +182,8 @@ Or if you are endorsing a vault from previous release:
 4. confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.
 
 ```python
- releaseDelta = self.numReleases - 1 - releaseTarget
+ releaseTarget = 3 # e.g vault api version 0.3.2
+ releaseDelta = registry.numReleases() - 1 - releaseTarget # (5-1-3) = 1
  strategy.acceptGovernance() # from ychad.eth
  registry.endorseVault(vault, releaseDelta) # from ychad.eth.
 ```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -178,7 +178,7 @@ Or if you are endorsing a vault from previous release:
 2. check the apiVersion of the vault you want to endorse to identify target release
 3. calculate the releaseDelta from your target release. (see registry endorseVault param details)
    E.g: latestRelease = 0.3.3 and numReleases = 5. New vault apiVersion is 0.3.2
-   `releaseDelta = self.numReleases - 1 - releaseTarget`
+   `releaseDelta = numReleases - 1 - releaseTarget`
 4. confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.
 
 ```python

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -175,8 +175,8 @@ registry.endorseVault(vault) # from ychad.eth
 Or if you are endorsing a vault from previous release:
 
 1. check for latest release number in the registry contract
-2. check the apiVersion of the vault you want to endorse
-3. calculate the releaseDelta to get target release. (see registry endorseVault param details)
+2. check the apiVersion of the vault you want to endorse to identify target release
+3. calculate the releaseDelta from your target release. (see registry endorseVault param details)
    E.g: latestRelease = 0.3.3 and numReleases = 5. New vault apiVersion is 0.3.2
    `releaseDelta = self.numReleases - 1 - releaseTarget`
 4. confirm using registry.releases(uint256) that your targetRelease has the same apiVersion as your vault.

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -44,17 +44,40 @@ def main():
     )
 
     latest_release = Version(registry.latestRelease())
+    num_releases = registry.numReleases() - 1
+    target_release_index = num_releases
+    release_delta = 0
+    click.echo(
+        f"""
+        Release Information
+
+        latest release version: {latest_release}
+          latest release index: {num_releases}
+         local package version: {PACKAGE_VERSION}
+        """
+    )
     use_proxy = False  # NOTE: Use a proxy to save on gas for experimental Vaults
-    if Version(PACKAGE_VERSION) < latest_release:
-        click.echo("Cannot deploy Vault for old API version")
-        return
+    if Version(PACKAGE_VERSION) <= latest_release:
+        click.echo(
+            f"""
+        Recommended Releases
+
+        Not Recommended => 0-2
+        0.3.2 => 3
+        0.3.3 => 4
+        0.3.4 => 5 
+        """
+        )
+        target_release_index = click.prompt(
+            "Please select a target release index from options or press enter for latest release:",
+            type=click.Choice([str(i) for i in range(num_releases + 1)]),
+            default=num_releases,
+        )
+        if click.confirm("Deploy a Proxy Vault", default="Y"):
+            use_proxy = True
     elif Version(PACKAGE_VERSION) > latest_release:
         if not click.confirm(f"Deploy {PACKAGE_VERSION} as new release"):
             return
-    else:
-        if not click.confirm("Deploy Experimental Vault"):
-            return
-        use_proxy = True
 
     token = Token.at(get_address("ERC20 Token"))
 
@@ -70,18 +93,23 @@ def main():
     guardian = get_address("Vault Guardian", default=dev.address)
     name = click.prompt(f"Set description", default=DEFAULT_VAULT_NAME(token))
     symbol = click.prompt(f"Set symbol", default=DEFAULT_VAULT_SYMBOL(token))
+    target_release = Vault.at(registry.releases(target_release_index)).apiVersion()
+    release_delta = num_releases - target_release_index
 
     click.echo(
         f"""
-    Vault Parameters
+    Vault Deployment Parameters
 
-   version: {PACKAGE_VERSION}
-     token: {token.address}
-  governer: {gov}
-   rewards: {rewards}
-  guardian: {guardian}
-      name: '{name}'
-    symbol: '{symbol}'
+         use proxy: {use_proxy}
+    target release: {target_release}
+     release delta: {release_delta}
+     token address: {token.address}
+      token symbol: {DEFAULT_VAULT_SYMBOL(token)}
+        governance: {gov}
+           rewards: {rewards}
+          guardian: {guardian}
+              name: '{name}'
+            symbol: '{symbol}'
     """
     )
 
@@ -97,6 +125,7 @@ def main():
         if use_proxy:
             # NOTE: Must always include guardian, even if default
             args.insert(2, guardian)
+            args.append(release_delta)
             txn_receipt = registry.newExperimentalVault(*args, {"from": dev})
             vault = Vault.at(txn_receipt.events["NewExperimentalVault"]["vault"])
             click.echo(f"Experimental Vault deployed [{vault.address}]")


### PR DESCRIPTION
Change Log:
-update ops checklist with new registry instructions for vault with prev release versions
-update deploy script to have option for different releases