### PR TITLE
refactor: delegated fees

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -210,6 +210,8 @@ abstract contract BaseStrategy {
      *  Strategy is somehow delegated inside another part of of Yearn's ecosystem e.g. another Vault.
      *  Note that this value must be strictly less than or equal to the amount provided by
      *  `estimatedTotalAssets()` below, as the TVL calc will be total assets minus delegated assets.
+     *  Also note that this value is used to determine the total assets under management by this
+     *  strategy, for the purposes of computing the management fee in `Vault`
      * @return
      *  The amount of assets this strategy manages that should not be included in Yearn's Total Value
      *  Locked (TVL) calculation across it's ecosystem.

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1648,7 +1648,11 @@ def report(gain: uint256, loss: uint256, _debtPayment: uint256) -> uint256:
     # Update cached value of delegated assets
     #   (used to properly account for mgmt fee in `_assessFees`)
     self.delegatedAssets -= self._strategy_delegatedAssets[msg.sender]
-    delegatedAssets: uint256 = Strategy(msg.sender).delegatedAssets()
+    # NOTE: Use `min(totalDebt, delegatedAssets)` as a guard against improper computation
+    delegatedAssets: uint256 = min(
+        self.strategies[msg.sender].totalDebt,
+        Strategy(msg.sender).delegatedAssets(),
+    )
     self.delegatedAssets += delegatedAssets
     self._strategy_delegatedAssets[msg.sender] = delegatedAssets
 

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -233,8 +233,8 @@ managementFee: public(uint256)
 # Governance Fee for performance of Vault (given to `rewards`)
 performanceFee: public(uint256)
 MAX_BPS: constant(uint256) = 10_000  # 100%, or 10k basis points
-# NOTE: A four-century period will be missing 3 of its 100 Julian leap years, leaving 97. 
-#       So the average year has 365 + 97/400 = 365.2425 days 
+# NOTE: A four-century period will be missing 3 of its 100 Julian leap years, leaving 97.
+#       So the average year has 365 + 97/400 = 365.2425 days
 #       ERROR(Julian): -0.0078
 #       ERROR(Gregorian): -0.0003
 SECS_PER_YEAR: constant(uint256) = 31_556_952  # 365.2425 days
@@ -444,7 +444,7 @@ def setRewards(rewards: address):
 def setLockedProfitDegration(degration: uint256):
     """
     @notice
-        Changes the locked profit degration. 
+        Changes the locked profit degration.
     @param degration The rate of degration in percent per second scaled to 1e18.
     """
     assert msg.sender == self.governance
@@ -887,7 +887,7 @@ def _shareValue(shares: uint256) -> uint256:
     # NOTE: using 1e3 for extra precision here, when decimals is low
     return ((10 ** 3 * (shares * freeFunds)) / self.totalSupply) / 10 ** 3
 
-    
+
 @view
 @internal
 def _sharesForAmount(amount: uint256) -> uint256:
@@ -1345,7 +1345,7 @@ def addStrategyToQueue(strategy: address):
         last_idx += 1
     # Check if queue is full
     assert last_idx < MAXIMUM_STRATEGIES
-        
+
     self.withdrawalQueue[MAXIMUM_STRATEGIES - 1] = strategy
     self._organizeWithdrawalQueue()
     log StrategyAddedToQueue(strategy)
@@ -1514,7 +1514,7 @@ def _reportLoss(strategy: address, loss: uint256):
     # Also, make sure we reduce our trust with the strategy by the same amount
     debtRatio: uint256 = self.strategies[strategy].debtRatio
     ratio_change: uint256 = min(loss * MAX_BPS / self._totalAssets(), debtRatio)
-    self.strategies[strategy].debtRatio -= ratio_change 
+    self.strategies[strategy].debtRatio -= ratio_change
     self.debtRatio -= ratio_change
 
 @internal

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -12,6 +12,7 @@ import {BaseStrategyInitializable, StrategyParams, VaultAPI} from "../BaseStrate
 
 contract TestStrategy is BaseStrategyInitializable {
     bool public doReentrancy;
+    bool public delegateEverything;
 
     // Some token that needs to be protected for some reason
     // Initialize this to some fake address, because we're just using it
@@ -24,6 +25,19 @@ contract TestStrategy is BaseStrategyInitializable {
         return string(abi.encodePacked("TestStrategy ", apiVersion()));
     }
 
+    // NOTE: This is a test-only function to simulate delegation
+    function _toggleDelegation() public {
+        delegateEverything = !delegateEverything;
+    }
+
+    function delegatedAssets() external override view returns (uint256) {
+        if (delegateEverything) {
+            return vault.strategies(address(this)).totalDebt;
+        } else {
+            return 0;
+        }
+    }
+
     // NOTE: This is a test-only function to simulate losses
     function _takeFunds(uint256 amount) public {
         want.safeTransfer(msg.sender, amount);
@@ -33,7 +47,7 @@ contract TestStrategy is BaseStrategyInitializable {
     function _toggleReentrancyExploit() public {
         doReentrancy = !doReentrancy;
     }
-    
+
     // NOTE: This is a test-only function to simulate a wrong want token
     function _setWant(IERC20 _want) public {
         want = _want;

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -65,3 +65,28 @@ def test_max_fees(gov, vault, token, TestStrategy, rewards, strategist):
         vault.updateStrategyPerformanceFee(
             strategy, FEE_MAX - vault_performance_fee + 1, {"from": gov}
         )
+
+
+def test_delegated_fees(chain, rewards, vault, strategy):
+    # Make sure funds are in the strategy
+    strategy.harvest()
+    assert strategy.estimatedTotalAssets() > 0
+
+    # Management fee is active...
+    bal_before = vault.balanceOf(rewards)
+    chain.mine(timedelta=60 * 60 * 24 * 365)  # Mine a year at 0% mgmt fee
+    strategy.harvest()
+    assert vault.balanceOf(rewards) > bal_before  # No increase in mgmt fees
+
+    # Check delegation math/logic
+    strategy._toggleDelegation()
+    assert strategy.delegatedAssets() == vault.strategies(strategy).dict()["totalDebt"]
+    assert vault.delegatedAssets() == 0  # NOTE: Cached 1 harvest period behind
+    strategy.harvest()
+    assert vault.delegatedAssets() == strategy.delegatedAssets()
+
+    # Delegated assets pay no fees (everything is delegated now)
+    bal_before = vault.balanceOf(rewards)
+    chain.mine(timedelta=60 * 60 * 24 * 365)  # Mine a year at 0% mgmt fee
+    strategy.harvest()
+    assert vault.balanceOf(rewards) == bal_before  # No increase in mgmt fees


### PR DESCRIPTION
This PR changes how fees are assessed such that `BaseStrategy.delegatedAssets` is pro-rated into the fee assessment. If a strategy delegates all of it's assets, there should be no fees earned by that strategy to either governance or the strategist themselves, and that portion of the assets loaned out shall earn no management fees either.

If only a portion is delegated (e.g. debt-based strategies where some of the funds are used to borrow against), that portion should be calculated such that the exact funds used to borrow are marked as delegated (e.g. Maker strategy w/ 200% debt ratio, then half the funds should be marked "delegated"). This is important to ensure than the degree of work is properly accounted for in how a strategy operates.

Strategists will need to be aware of properly reporting `delegatedAssets` and ensure it is strictly less than or equal to the total debt, or else the calculations will revert or be processed improperly.