### PR TITLE
fix: prevent mgmt fee from creating negative APY situation

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1538,6 +1538,8 @@ def _assessFees(strategy: address, gain: uint256):
         / MAX_BPS
         / SECS_PER_YEAR
     )
+    if governance_fee > gain:
+        governance_fee = gain # Prevent mgmt fee from incurring negative APY when harvest generates 0 yield
     strategist_fee: uint256 = 0  # Only applies in certain conditions
 
     # NOTE: Applies if Strategy is not shutting down, or it is but all debt paid off


### PR DESCRIPTION
WBTC vault currently shows negative APY because mgmt fee is taking a 2% cut on unprofitable harvests. This fix will prevent mgmt fee from exceeding gains on report. An edge case will still exist where a non-zero profit is reported, but performance fees cause APY to be negative.