### PR TITLE
test: hardhat compatibility

### DIFF
--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -44,13 +44,13 @@ def test_harvest_tend_trigger(chain, gov, vault, token, TestStrategy):
     # Check that trigger works if gas costs is less than profitFactor
     profit = 10 ** token.decimals()
     token.transfer(strategy, profit, {"from": gov})
-    chain.mine(timedelta=strategy.minReportDelay())
+    chain.mine(timedelta=strategy.minReportDelay() + 5)
     assert not strategy.harvestTrigger(profit // strategy.profitFactor())
     assert strategy.harvestTrigger(profit // strategy.profitFactor() - 1)
     strategy.harvest({"from": gov})
 
     # Check that trigger works if strategy is in debt using debt threshold
-    chain.mine(timedelta=strategy.minReportDelay())
+    chain.mine(timedelta=strategy.minReportDelay() + 5)
     assert vault.debtOutstanding(strategy) == 0
     vault.revokeStrategy(strategy, {"from": gov})
     assert vault.debtOutstanding(strategy) > strategy.debtThreshold()


### PR DESCRIPTION
We had a fix for mismatching `chain.id` and `chainid()` (1337 vs 1) in ganache, but hardhat doesn't have this problem (both are 31337). This change only applies the fix for ganache. This only affects `permit` tests.