### PR TITLE
fix: affiliate token withdraw calculation

### DIFF
--- a/contracts/test/AffiliateToken.sol
+++ b/contracts/test/AffiliateToken.sol
@@ -92,9 +92,9 @@ contract AffiliateToken is ERC20, BaseWrapper {
         return withdraw(balanceOf(msg.sender));
     }
 
-    function withdraw(uint256 shares) public returns (uint256) {
+    function withdraw(uint256 shares) public returns (uint256 withdrawn) {
+        withdrawn = _withdraw(address(this), msg.sender, _shareValue(shares), true); // `true` = withdraw from `bestVault`
         _burn(msg.sender, shares);
-        return _withdraw(address(this), msg.sender, _shareValue(shares), true); // `true` = withdraw from `bestVault`
     }
 
     function migrate() external onlyAffiliate returns (uint256) {


### PR DESCRIPTION
I believe the withdrawal functionality in AffiliateToken.sol is incorrect due to the ordering of operations within the function. The shares are burned before the _shareValue() call within the function (which returns the number of underlying tokens the burned shares can be redeemed for). This results in the totalSupply() being different than expected within this calculation.

As an example scenario:

### Setup
- An ERC20 token (mockToken) was deployed
- Yearn Token Vault V 0.2.11 was deployed and initialized with the ERC20 token's address.
- The vault's deposit limit was set to 24 (mockToken)
- Yearn's Registry V 0.2.11 was deployed
- The vault was added as a newRelease to the registry and it was endorsed with endorseVault.
- The AffiliateToken wrapper was deployed with the mockToken's address and the registry address.

### Deposit / Withdraw Flow
- A user deposits 1 mockToken and receives 1 share
- Another user deposits all their tokens (10) and receives 10 shares
- Afterwards, when the first user attempts to withdraw 0.5 mockTokens, the contract returns 0.523809523809523809 mockTokens to him instead.

In the original unfixed version the pps looked like this:

```
-- 1st User Deposits 1 --
Wrapper's PPS: 1000000000000000000
Vault's PPS: 1000000000000000000
-- 2nd User Deposits 10 --
Wrapper's PPS: 1000000000000000000
Vault's PPS: 1000000000000000000
-- 1st User withdraws 0.5 --
Wrapper's PPS: 997732426303854875
Vault's PPS: 1000000000000000000
-- 2nd User withdraws 10 --
Wrapper's PPS: 0
Vault's PPS: 1000000000000000000
```
In the fixed version the pps is 1000000000000000000 throughout as expected.

Credit to @sajanrajdev and @Grandthrax for uncovering and debugging this issue.

The test file demonstrating the issue: https://github.com/Badger-Finance/badger-system/blob/yearn-test/tests/sett/test_yearn_wrapper.py

A commit resolving the issue on the Badger wrapper variant: https://github.com/Badger-Finance/badger-system/commit/238ccad464d2ee11e46654e3db8ff059ecbe204c