### PR TITLE
fix: prevent shares from being deposited to wrong address

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -625,7 +625,7 @@ def _transfer(sender: address, receiver: address, amount: uint256):
     # See note on `transfer()`.
 
     # Protect people from accidentally sending their shares to bad places
-    assert not (receiver in [self, ZERO_ADDRESS])
+    assert receiver not in [self, ZERO_ADDRESS]
     self.balanceOf[sender] -= amount
     self.balanceOf[receiver] += amount
     log Transfer(sender, receiver, amount)
@@ -850,6 +850,7 @@ def deposit(_amount: uint256 = MAX_UINT256, recipient: address = msg.sender) -> 
     @return The issued Vault shares.
     """
     assert not self.emergencyShutdown  # Deposits are locked out
+    assert recipient not in [self, ZERO_ADDRESS]
 
     amount: uint256 = _amount
 

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -32,6 +32,15 @@ def test_deposit_with_wrong_amount(vault, token, gov):
         vault.deposit(balance, {"from": gov})
 
 
+def test_deposit_with_wrong_recipient(vault, token, gov):
+    balance = token.balanceOf(gov)
+    token.approve(vault, 2 ** 256 - 1, {"from": gov})
+    with brownie.reverts():
+        vault.deposit(
+            balance, "0x0000000000000000000000000000000000000000", {"from": gov}
+        )
+
+
 def test_deposit_with_guest_list(vault, guest_list, token, gov, rando, history):
     # Make sure we're attempting to deposit something
     token.transfer(rando, token.balanceOf(gov) // 2, {"from": gov})


### PR DESCRIPTION
fixes #276 