### PR TITLE
chore: check PR titles for conventional commits

### DIFF
--- a/.github/workflows/title.yaml
+++ b/.github/workflows/title.yaml
@@ -1,0 +1,26 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v2
+
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+              python-version: 3.8
+
+        - name: Install Dependencies
+          run: pip install commitzen
+
+        - name: Check PR Title
+          run: cz check --message "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
This makes sure when we use the "squash and merge" feature, the default option for the squash commit message (e.g. the PR title) is compliant with conventional commits