### PR TITLE
docs: Update documentation on prepareReturn

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -757,7 +757,10 @@ abstract contract BaseStrategy {
     /**
      * Do anything necessary to prepare this Strategy for migration, such as
      * transferring any reserve or LP tokens, CDPs, or other tokens or stores of
-     * value.
+     * value. This function may be used as an escape hatch from broken code in
+     * either the strategy or underlying protocol, and therefore should avoid 
+     * any non-critical logic (e.g. claiming rewards) to prevent a scenario 
+     * where a revert blocks our ability to successfully migrate.
      */
     function prepareMigration(address _newStrategy) internal virtual;
 


### PR DESCRIPTION
* docs: update `prepareReturn` documentation to highlight that this is one of the few tools we have to recover from broken code and therefore should be treated with utmost safety, minimizing surface area for revert potential.