### PR TITLE
feat: setEmergencyExit should allow to be called by vault guardian and vault management

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -273,6 +273,14 @@ abstract contract BaseStrategy {
         _;
     }
 
+    modifier onlyEmergencyAuthorized() {
+        require(
+            msg.sender == strategist || msg.sender == governance() || msg.sender == vault.guardian() || msg.sender == vault.management(),
+            "!authorized"
+        );
+        _;
+    }
+
     modifier onlyStrategist() {
         require(msg.sender == strategist, "!strategist");
         _;
@@ -787,7 +795,7 @@ abstract contract BaseStrategy {
      * @dev
      *  See `vault.setEmergencyShutdown()` and `harvest()` for further details.
      */
-    function setEmergencyExit() external onlyAuthorized {
+    function setEmergencyExit() external onlyEmergencyAuthorized {
         emergencyExit = true;
         vault.revokeStrategy();
 

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -127,11 +127,7 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain, withSurplus)
 def test_set_emergency_exit_authority(
     strategy, gov, strategist, keeper, rando, management, guardian
 ):
-    # Can only setEmergencyExit as governance or strategist
-    with brownie.reverts("!authorized"):
-        strategy.setEmergencyExit({"from": management})
-    with brownie.reverts("!authorized"):
-        strategy.setEmergencyExit({"from": guardian})
+    # Can only setEmergencyExit as governance, strategist, vault management and guardian
     with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": keeper})
     with brownie.reverts("!authorized"):
@@ -139,3 +135,7 @@ def test_set_emergency_exit_authority(
     strategy.setEmergencyExit({"from": gov})
     brownie.chain.undo()
     strategy.setEmergencyExit({"from": strategist})
+    brownie.chain.undo()
+    strategy.setEmergencyExit({"from": management})
+    brownie.chain.undo()
+    strategy.setEmergencyExit({"from": guardian})


### PR DESCRIPTION
fixes #294 