### PR TITLE
fix: divide by 0 error in _reportLoss (#306)

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -978,7 +978,9 @@ def _reportLoss(strategy: address, loss: uint256):
     # Also, make sure we reduce our trust with the strategy by the same amount
     debtRatio: uint256 = self.strategies[strategy].debtRatio
     precisionFactor: uint256 = self.precisionFactor
-    ratio_change: uint256 = min(precisionFactor * loss * MAX_BPS / self._totalAssets() / precisionFactor, debtRatio)
+    ratio_change: uint256 = debtRatio
+    if self._totalAssets() > 0:
+        ratio_change = min(precisionFactor * loss * MAX_BPS / self._totalAssets() / precisionFactor, ratio_change)
     self.strategies[strategy].debtRatio -= ratio_change
     self.debtRatio -= ratio_change
 

--- a/tests/functional/vault/test_losses.py
+++ b/tests/functional/vault/test_losses.py
@@ -58,3 +58,21 @@ def test_losses(chain, vault, strategy, gov, token):
     params = vault.strategies(strategy).dict()
     assert params["totalLoss"] == 500
     assert params["totalDebt"] == 0
+
+
+def test_total_loss(chain, vault, strategy, gov, token):
+    vault.addStrategy(strategy, 10_000, 0, 2 ** 256 - 1, 1_000, {"from": gov})
+    token.approve(vault, 2 ** 256 - 1, {"from": gov})
+    vault.deposit(5000, {"from": gov})
+
+    strategy.harvest({"from": gov})
+    assert token.balanceOf(strategy) == 5000
+
+    # send all our tokens back to the token contract
+    token.transfer(token, token.balanceOf(strategy), {"from": strategy})
+
+    strategy.harvest({"from": gov})
+    params = vault.strategies(strategy)
+    assert params["totalLoss"] == 5000
+    assert params["totalDebt"] == 0
+    assert params["debtRatio"] == 0


### PR DESCRIPTION
This PR fixes a divide by 0 error that manifests when a vault has a total loss and `harvest` is called. The divide by 0 is only triggered when there is a total loss. Included is a new test that demonstrates the issue when run against the existing `master` branch but is fixed in this PR.

fixes #306 