### PR TITLE
fix: comments in Vault.vy 

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -263,7 +263,7 @@ def initialize(
         If `nameOverride` is not specified, the name will be 'yearn'
         combined with the name of `token`.
 
-        If `symbolOverride` is not specified, the symbol will be 'y'
+        If `symbolOverride` is not specified, the symbol will be 'yv'
         combined with the symbol of `token`.
     @param token The token that may be deposited into this Vault.
     @param governance The address authorized for governance interactions.

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -797,7 +797,7 @@ def _issueSharesForAmount(to: address, amount: uint256) -> uint256:
     # calculation will be wrong. This means that only *trusted* tokens
     # (with no capability for exploitative behavior) can be used.
     shares: uint256 = 0
-    # HACK: Saves 2 SLOADs (~4000 gas)
+    # HACK: Saves 2 SLOADs (~200 gas, post-Berlin)
     totalSupply: uint256 = self.totalSupply
     if totalSupply > 0:
         # Mint amount of shares based on what the Vault is managing overall


### PR DESCRIPTION
Fix comments in `Vault.vy`

1. The default symbol starts with `yv` instead of `y`
2. Gas of 2 SLOADs drops from 4000 to 200.