### PR TITLE
perf: assess fees develop

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1599,6 +1599,7 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
     #       or the calculation will be wrong!
     # NOTE: This must be done at the same time, to ensure the relative
     #       ratio of governance_fee : strategist_fee is kept intact
+    assert performance_fee + strategist_fee <= gain
     total_fee: uint256 = performance_fee + strategist_fee + management_fee
     # ensure total_fee is not more than gain
     if total_fee > gain:

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1571,6 +1571,9 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
     duration: uint256 = block.timestamp - self.strategies[strategy].lastReport
     assert duration != 0 # can't assessFees twice within the same block
 
+    if gain == 0:
+        return 0
+
     management_fee: uint256 = (
         (
             (self.strategies[strategy].totalDebt - Strategy(strategy).delegatedAssets())
@@ -1581,21 +1584,16 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
         / SECS_PER_YEAR
     )
 
-    # Only applies in certain conditions
-    strategist_fee: uint256 = 0
-    performance_fee: uint256 = 0
-
     # NOTE: Applies if Strategy is not shutting down, or it is but all debt paid off
     # NOTE: No fee is taken when a Strategy is unwinding it's position, until all debt is paid
-    if gain > 0:
-        # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
-        strategist_fee = (
-            gain
-            * self.strategies[strategy].performanceFee
-            / MAX_BPS
-        )
-        # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
-        performance_fee = gain * self.performanceFee / MAX_BPS
+    # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
+    strategist_fee: uint256 = (
+        gain
+        * self.strategies[strategy].performanceFee
+        / MAX_BPS
+    )
+    # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
+    performance_fee: uint256 = gain * self.performanceFee / MAX_BPS
 
     # NOTE: This must be called prior to taking new collateral,
     #       or the calculation will be wrong!


### PR DESCRIPTION
prevent overflow
probable    self.performanceFee + self.strategies[strategy].performanceFee >= MAX_BPS 
https://github.com/yearn/yearn-vaults/blob/eb575fd1bba029aab86227ffae5a4c0bdeb37957/contracts/Vault.vy#L451-L463