### PR TITLE
perf: _assessFees

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1584,7 +1584,7 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
         / SECS_PER_YEAR
     )
 
-    self. managementDebt +=  management_fee
+    self.managementDebt +=  management_fee
 
     if gain == 0:
         return 0
@@ -1607,11 +1607,11 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
     #       or the calculation will be wrong!
     # NOTE: This must be done at the same time, to ensure the relative
     #       ratio of governance_fee : strategist_fee is kept intact
-    total_fee: uint256 = performance_fee + strategist_fee + self. managementDebt
-    self. managementDebt = 0
+    total_fee: uint256 = performance_fee + strategist_fee + self.managementDebt
+    self.managementDebt = 0
     # ensure total_fee is not more than gain
     if total_fee > gain:
-        self. managementDebt = total_fee - gain
+        self.managementDebt = total_fee - gain
         total_fee = gain
     if total_fee > 0:  # NOTE: If mgmt fee is 0% and no gains were realized, skip
         reward: uint256 = self._issueSharesForAmount(self, total_fee)

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1575,6 +1575,8 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
     if gain == 0:
         return 0
 
+    assert self.strategies[strategy].performanceFee + self.performanceFee <= MAX_BPS
+
     management_fee: uint256 = (
         (
             (self.strategies[strategy].totalDebt - Strategy(strategy).delegatedAssets())

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1572,6 +1572,9 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
     duration: uint256 = block.timestamp - self.strategies[strategy].lastReport
     assert duration != 0 # can't assessFees twice within the same block
 
+    if gain == 0:
+        return 0
+
     management_fee: uint256 = (
         (
             (self.strategies[strategy].totalDebt - Strategy(strategy).delegatedAssets())
@@ -1582,21 +1585,16 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
         / SECS_PER_YEAR
     )
 
-    # Only applies in certain conditions
-    strategist_fee: uint256 = 0
-    performance_fee: uint256 = 0
-
     # NOTE: Applies if Strategy is not shutting down, or it is but all debt paid off
     # NOTE: No fee is taken when a Strategy is unwinding it's position, until all debt is paid
-    if gain > 0:
-        # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
-        strategist_fee = (
-            gain
-            * self.strategies[strategy].performanceFee
-            / MAX_BPS
-        )
-        # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
-        performance_fee = gain * self.performanceFee / MAX_BPS
+    # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
+    strategist_fee: uint256 = (
+        gain
+        * self.strategies[strategy].performanceFee
+        / MAX_BPS
+    )
+    # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
+    performance_fee: uint256 = gain * self.performanceFee / MAX_BPS
 
     # NOTE: This must be called prior to taking new collateral,
     #       or the calculation will be wrong!

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -80,7 +80,8 @@ def test_delegated_fees(chain, rewards, vault, strategy, gov, token):
     # Management fee is active...
     bal_before = vault.balanceOf(rewards)
     chain.mine(timedelta=60 * 60 * 24 * 365)  # Mine a year at 2% mgmt fee
-    token.transfer(strategy, 10 ** token.decimals())
+    amount = vault.strategies(strategy).dict()["totalDebt"] * 3 / 100
+    token.transfer(strategy, amount)
     strategy.harvest()
     assert vault.balanceOf(rewards) > bal_before  # increase in mgmt fees
 


### PR DESCRIPTION
#345 
prevent overflow
probable    self.performanceFee + self.strategies[strategy].performanceFee >= MAX_BPS 
https://github.com/yearn/yearn-vaults/blob/eb575fd1bba029aab86227ffae5a4c0bdeb37957/contracts/Vault.vy#L451-L463