### PR TITLE
fix: strategy performance fee

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1282,7 +1282,7 @@ def updateStrategyPerformanceFee(
     @param performanceFee The new fee the strategist will receive.
     """
     assert msg.sender == self.governance
-    assert performanceFee <= MAX_BPS - self.performanceFee
+    assert performanceFee <= MAX_BPS / 2
     assert self.strategies[strategy].activation > 0
     self.strategies[strategy].performanceFee = performanceFee
     log StrategyUpdatePerformanceFee(strategy, performanceFee)

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -108,6 +108,8 @@ def test_gain_less_than_fees(chain, rewards, vault, strategy, gov, token):
     strategy.harvest()
     assert strategy.estimatedTotalAssets() > 0
 
+    token.transfer(strategy, 10 ** token.decimals())
+
     # Governance and strategist have not earned any fees yet
     assert vault.balanceOf(rewards) == 0
     assert vault.balanceOf(strategy) == 0


### PR DESCRIPTION
assert performanceFee <= MAX_BPS - self.performanceFee 
change to
assert performanceFee <= MAX_BPS / 2