### PR TITLE
fix: delete assert self.debtRatio <= MAX_BPS

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1181,7 +1181,6 @@ def addStrategy(
     assert self.token.address == Strategy(strategy).want()
 
     # Check strategy parameters
-    assert self.debtRatio + debtRatio <= MAX_BPS
     assert minDebtPerHarvest <= maxDebtPerHarvest
     assert performanceFee <= MAX_BPS / 2 
 
@@ -1225,7 +1224,6 @@ def updateStrategyDebtRatio(
     self.debtRatio -= self.strategies[strategy].debtRatio
     self.strategies[strategy].debtRatio = debtRatio
     self.debtRatio += debtRatio
-    assert self.debtRatio <= MAX_BPS
     log StrategyUpdateDebtRatio(strategy, debtRatio)
 
 
@@ -1472,10 +1470,12 @@ def _creditAvailable(strategy: address) -> uint256:
     # See note on `creditAvailable()`.
     if self.emergencyShutdown:
         return 0
+    if self.debtRatio == 0:
+        return 0
     vault_totalAssets: uint256 = self._totalAssets()
-    vault_debtLimit: uint256 =  self.debtRatio * vault_totalAssets / MAX_BPS 
+    vault_debtLimit: uint256 =  vault_totalAssets
     vault_totalDebt: uint256 = self.totalDebt
-    strategy_debtLimit: uint256 = self.strategies[strategy].debtRatio * vault_totalAssets / MAX_BPS
+    strategy_debtLimit: uint256 = self.strategies[strategy].debtRatio * vault_totalAssets / self.debtRatio
     strategy_totalDebt: uint256 = self.strategies[strategy].totalDebt
     strategy_minDebtPerHarvest: uint256 = self.strategies[strategy].minDebtPerHarvest
     strategy_maxDebtPerHarvest: uint256 = self.strategies[strategy].maxDebtPerHarvest

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -334,7 +334,7 @@ def test_profit_degradation(chain, gov, token, vault, strategy, rando):
 
     assert vault.totalSupply() == 0
     assert (
-        token.balanceOf(vault) > 0
+        vault.totalAssets() > 0
     )  # all money withdrawn but some profit left locked for 6 hours
 
     vault.deposit(deposit, {"from": gov})


### PR DESCRIPTION
update self debt Ratio usage
This is a better way to control assets.
Solve a small part of this issue #376 

origin:
vault_debtLimit: uint256 = self.debtRatio * vault_totalAssets / MAX_BPS 
If this control is needed. we should add other var control it.