### PR TITLE
fix: revert debt calculation changes.

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -968,7 +968,12 @@ def _reportLoss(strategy: address, loss: uint256):
 
     # Also, make sure we reduce our trust with the strategy by the same amount
     debtRatio: uint256 = self.strategies[strategy].debtRatio
-    ratio_change: uint256 = min(loss * MAX_BPS / self._totalAssets(), debtRatio)
+    ratio_change: uint256 = 0
+    if self._totalAssets() == 0: # No more assets, debt goes to zero.
+       ratio_change = self.strategies[strategy].debtRatio
+    else: 
+       ratio_change = min(loss * MAX_BPS / self._totalAssets(), debtRatio)
+
     self.strategies[strategy].debtRatio -= ratio_change
     self.debtRatio -= ratio_change
 


### PR DESCRIPTION
If we can't find a way to calculate debRatio without using the total assets.
This reverts commit cd75f52f99e08308258b1c6cf809a107fcbd7519.