### PR TITLE
fix: apply performance fee only to gain on undelegated assets

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1602,7 +1602,7 @@ def _assessFees(strategy: address, gain: uint256) -> uint256:
             / SECS_PER_YEAR
         )
 
-         # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
+        # NOTE: Unlikely to throw unless strategy reports >1e72 harvest profit
         performance_fee = (
             # NOTE: Fee is applied to gain in same ratio as we have for undelegated assets to total assets
             gain


### PR DESCRIPTION
Right now governance takes an extra 10% performance fee from strategies that delegate. This fix uses same methodology used to compute management fee based on delegated assets, and applies it to performance fee to prevent a double-dip, making delegated strategies more viable.