### PR TITLE
fix: removed anti-patterns from tests

### DIFF
--- a/tests/functional/vault/test_misc.py
+++ b/tests/functional/vault/test_misc.py
@@ -73,7 +73,7 @@ def test_credit_available_minDebtPerHarvest_larger_than_available(
     strategyDebtExceedsLimit = strategy_totalDebt >= strategy_debtLimit
     vaultDebtExceedsLimit = vault_totalDebt >= vault_debtLimit
     exhaustedCreditLine = vaultDebtExceedsLimit or strategyDebtExceedsLimit
-    assert exhaustedCreditLine == False
+    assert not exhaustedCreditLine
 
     # Start with debt limit left for the Strategy
     available = strategy_debtLimit - strategy_totalDebt
@@ -87,7 +87,7 @@ def test_credit_available_minDebtPerHarvest_larger_than_available(
     vault.updateStrategyMinDebtPerHarvest(strategy, available + 1, {"from": gov})
     strategy_minDebtPerHarvest = vault.strategies(strategy).dict()["minDebtPerHarvest"]
     minDebtPerHarvestExceedsAvailable = strategy_minDebtPerHarvest > available
-    assert minDebtPerHarvestExceedsAvailable == True
+    assert minDebtPerHarvestExceedsAvailable
 
     creditAvalable = vault.creditAvailable(strategy)
     assert creditAvalable == 0

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -329,7 +329,8 @@ def test_ordering(gov, vault, TestStrategy, rando):
             {"from": gov},
         )
 
-    [vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov}) for s in strategies]
+    for s in strategies:
+        vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov})
 
     for idx, strategy in enumerate(strategies):
         assert vault.withdrawalQueue(idx) == strategy
@@ -465,7 +466,8 @@ def test_addStategyToQueue(
 
     # Can't add a strategy to an already full queue
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(20)]
-    [vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov}) for s in strategies]
+    for s in strategies:
+        vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov}) 
     with brownie.reverts():
         vault.addStrategyToQueue(strategy, {"from": gov})
 

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -467,7 +467,7 @@ def test_addStategyToQueue(
     # Can't add a strategy to an already full queue
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(20)]
     for s in strategies:
-        vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov}) 
+        vault.addStrategy(s, 100, 10, 20, 1000, {"from": gov})
     with brownie.reverts():
         vault.addStrategyToQueue(strategy, {"from": gov})
 

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -32,7 +32,7 @@ def test_multiple_withdrawals(token, gov, Vault, TestStrategy, chain):
     chain.sleep(1)
 
     for s in strategies:  # Seed all the strategies with debt
-        s.harvest({"from": gov}) 
+        s.harvest({"from": gov})
 
     assert token.balanceOf(vault) == starting_balance // 2  # 50% in strategies
     for s in strategies:  # All of them have debt (10% each)
@@ -142,7 +142,7 @@ def test_progressive_withdrawal(
 
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(2)]
     for s in strategies:
-        vault.addStrategy(s, 1000, 0, 10, 1000, {"from": gov}) 
+        vault.addStrategy(s, 1000, 0, 10, 1000, {"from": gov})
 
     token.approve(vault, 2 ** 256 - 1, {"from": gov})
     vault.deposit(1000, {"from": gov})

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -20,7 +20,7 @@ def test_multiple_withdrawals(token, gov, Vault, TestStrategy, chain):
 
     starting_balance = token.balanceOf(vault)
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
-    [
+    for s in strategies:
         vault.addStrategy(
             s,
             1_000,  # 10% of all tokens in Vault
@@ -29,11 +29,10 @@ def test_multiple_withdrawals(token, gov, Vault, TestStrategy, chain):
             0,  # No fee
             {"from": gov},
         )
-        for s in strategies
-    ]
     chain.sleep(1)
 
-    [s.harvest({"from": gov}) for s in strategies]  # Seed all the strategies with debt
+    for s in strategies:  # Seed all the strategies with debt
+        s.harvest({"from": gov}) 
 
     assert token.balanceOf(vault) == starting_balance // 2  # 50% in strategies
     for s in strategies:  # All of them have debt (10% each)
@@ -57,7 +56,8 @@ def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
     vault.setManagementFee(0, {"from": gov})  # Just makes it easier later
     # Add strategies
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
-    [vault.addStrategy(s, 2_000, 0, 10 ** 21, 1000, {"from": gov}) for s in strategies]
+    for s in strategies:
+        vault.addStrategy(s, 2_000, 0, 10 ** 21, 1000, {"from": gov})
 
     # Send tokens to random user
     token.approve(gov, 2 ** 256 - 1, {"from": gov})
@@ -78,7 +78,8 @@ def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
     # the vault and the strategies
     while vault.totalDebt() < vault.totalAssets():
         chain.sleep(1)
-        [s.harvest({"from": gov}) for s in strategies]
+        for s in strategies:
+            s.harvest({"from": gov})
         with brownie.reverts():
             vault.withdraw(5000, {"from": rando})
 
@@ -140,7 +141,8 @@ def test_progressive_withdrawal(
     vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
 
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(2)]
-    [vault.addStrategy(s, 1000, 0, 10, 1000, {"from": gov}) for s in strategies]
+    for s in strategies:
+        vault.addStrategy(s, 1000, 0, 10, 1000, {"from": gov}) 
 
     token.approve(vault, 2 ** 256 - 1, {"from": gov})
     vault.deposit(1000, {"from": gov})
@@ -153,7 +155,8 @@ def test_progressive_withdrawal(
 
     # Deposit something in strategies
     chain.sleep(1)  # Needs to be a second ahead, at least
-    [s.harvest({"from": gov}) for s in strategies]
+    for s in strategies:
+        s.harvest({"from": gov})
     assert token.balanceOf(vault) < vault.totalAssets()  # Some debt is in strategies
 
     # Trying to withdraw 0 shares. It should revert


### PR DESCRIPTION
Don't use List generator for looping or side-effect.
It will unnecessarily waste memory.