### PR TITLE
feat: simple router

### DIFF
--- a/contracts/Router.sol
+++ b/contracts/Router.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+import {VaultAPI} from "./BaseStrategy.sol";
+
+interface RegistryAPI {
+    function governance() external view returns (address);
+
+    function latestVault(address token) external view returns (address);
+
+    function numVaults(address token) external view returns (uint256);
+
+    function vaults(address token, uint256 deploymentId) external view returns (address);
+}
+
+contract Router {
+    RegistryAPI public registry;
+    uint256 constant DEPOSIT_EVERYTHING = type(uint256).max;
+    uint256 constant UNLIMITED_APPROVAL = type(uint256).max;
+
+    constructor(address _registry) public {
+        // Recommended to use `v2.registry.ychad.eth`
+        registry = RegistryAPI(_registry);
+    }
+
+    function deposit(
+        IERC20 _token, // Token to deposit
+        uint256 amount // if `MAX_UINT256`, just deposit everything
+    ) public {
+        VaultAPI vault = latestVault(address(_token));
+        assert(address(vault) != 0x0000000000000000000000000000000000000000);
+        if (amount == DEPOSIT_EVERYTHING) {
+            amount = _token.balanceOf(msg.sender);
+        }
+        SafeERC20.safeTransferFrom(_token, msg.sender, address(this), amount);
+
+        if (_token.allowance(address(this), address(vault)) < amount) {
+            SafeERC20.safeApprove(_token, address(vault), 0); // Avoid issues with some tokens requiring 0
+            SafeERC20.safeApprove(_token, address(vault), UNLIMITED_APPROVAL); // Vaults are trusted
+        }
+
+        vault.deposit(amount, msg.sender);
+    }
+
+    /* @notice
+     *  Used to get the most recent vault for the token using the registry.
+     * @return An instance of a VaultAPI
+     */
+    function latestVault(address _token) public view virtual returns (VaultAPI) {
+        return VaultAPI(registry.latestVault(_token));
+    }
+}

--- a/tests/functional/router/conftest.py
+++ b/tests/functional/router/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture
+def vault(gov, management, token, create_vault):
+    vault = create_vault(token, version="0.4.1", governance=gov)
+    vault.setManagement(management, {"from": gov})
+    yield vault
+
+
+@pytest.fixture
+def vault2(gov, management, token, create_vault):
+    vault = create_vault(token=token, governance=gov)
+    vault.setManagement(management, {"from": gov})
+    yield vault
+
+
+@pytest.fixture
+def router(gov, registry, Router):
+    yield gov.deploy(Router, registry)

--- a/tests/functional/router/test_routing.py
+++ b/tests/functional/router/test_routing.py
@@ -1,0 +1,24 @@
+import pytest
+import brownie
+from brownie import ZERO_ADDRESS
+
+
+def test_router(router, registry, token, vault, vault2, gov):
+    token.approve(router, 2000, {"from": gov})
+
+    # revert no vault
+    with brownie.reverts():
+        router.deposit(token, 1000, {"from": gov})
+
+    registry.newRelease(vault, {"from": gov})
+    registry.endorseVault(vault, {"from": gov})
+    assert token.balanceOf(vault) == 0
+    router.deposit(token, 1000, {"from": gov})
+    assert token.balanceOf(vault) == 1000
+
+    # endorse new version
+    registry.newRelease(vault2, {"from": gov})
+    registry.endorseVault(vault2, {"from": gov})
+    assert token.balanceOf(vault2) == 0
+    router.deposit(token, 1000, {"from": gov})
+    assert token.balanceOf(vault2) == 1000


### PR DESCRIPTION
minimal implementation of a router for integrators.

Things that can be added/improved:

- Gas savings: Cache registry
- Gas savings: Add param to deposit `deposit(amount, receiver, depositor)` to reduce the number of transfers
- Add withdraw function 

@fameal @lehnberg 

It might not be the right repo to add this code to.