### PR TITLE
feat: test small losses

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1003,8 +1003,10 @@ def _reportLoss(strategy: address, loss: uint256):
             loss * self.debtRatio / self.totalDebt,
             self.strategies[strategy].debtRatio,
         )
-        self.strategies[strategy].debtRatio -= ratio_change
-        self.debtRatio -= ratio_change
+        # If the loss is too small, ratio_change will be 0
+        if ratio_change != 0:
+            self.strategies[strategy].debtRatio -= ratio_change
+            self.debtRatio -= ratio_change
     # Finally, adjust our strategy's parameters by the loss
     self.strategies[strategy].totalLoss += loss
     self.strategies[strategy].totalDebt = totalDebt - loss


### PR DESCRIPTION
Here's an edge case of small loss not dropping the debt ratio.
The "root issue" is:
 
```
ratio_change: uint256 = min(
            loss * self.debtRatio / self.totalDebt,
            self.strategies[strategy].debtRatio,
        )
```

min there works like `min(int(a), int(b))`. if loss is small enough, `loss * self.debtRatio / self.totalDebt` will be greater than 0 but smaller than 1.
