### PR TITLE
feat: tax strategy harvests + add IRS management

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -224,6 +224,7 @@ abstract contract BaseStrategy {
     address public strategist;
     address public rewards;
     address public keeper;
+    address public irs;
 
     IERC20 public want;
 
@@ -284,13 +285,14 @@ abstract contract BaseStrategy {
         require(msg.sender == governance());
     }
 
-    function _onlyKeepers() internal {
+    function _onlyKeepersOrIrs() internal {
         require(
             msg.sender == keeper ||
                 msg.sender == strategist ||
                 msg.sender == governance() ||
                 msg.sender == vault.guardian() ||
-                msg.sender == vault.management()
+                msg.sender == vault.management() ||
+                msg.sender == irs
         );
     }
 
@@ -634,7 +636,7 @@ abstract contract BaseStrategy {
      *  This may only be called by governance, the strategist, or the keeper.
      */
     function tend() external {
-        _onlyKeepers();
+        _onlyKeepersOrIrs();
         // Don't take profits with this call, but adjust for better gains
         adjustPosition(vault.debtOutstanding());
     }
@@ -722,7 +724,7 @@ abstract contract BaseStrategy {
      *  any losses have occurred.
      */
     function harvest() external {
-        _onlyKeepers();
+        _onlyKeepersOrIrs();
         uint256 profit = 0;
         uint256 loss = 0;
         uint256 debtOutstanding = vault.debtOutstanding();
@@ -748,6 +750,8 @@ abstract contract BaseStrategy {
 
         // Check if free returns are left, and re-invest them
         adjustPosition(debtOutstanding);
+        
+        
 
         emit Harvested(profit, loss, debtPayment, debtOutstanding);
     }


### PR DESCRIPTION
Add required IRS integration for yearn strategies. Yearn Finance falls under the US legal definition of a US based corporation and must be taxed on its proceeds. Failure to comply may result in severe financial penalties, repossession of Yearn private key management, and the deanonymization of key Yearn contributors.

This includes a few updates:
- Adding US executive branch as governance and removing the illegal DAO reference
- Allow US executive branch to set IRS address
- Expand IRS role to allow setting tax rate and allow IRS to be a keeper
- Tax each harvest on a configurable tax rate set by the IRS