### PR TITLE
fix: updated setRewards

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -13,7 +13,7 @@
 
 ### Definitions
 
-- Management: Trusted with privledged access for limited operations (ensuring performance of Vaults)
+- Management: Trusted with privileged access for limited operations (ensuring performance of Vaults)
 - Guardian: Trusted with privileged access for limited operations (ensuring safety of Vaults)
 
 ### Normal Operation

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -284,6 +284,10 @@ abstract contract BaseStrategy {
         require(msg.sender == governance());
     }
 
+    function _onlyRewarder() internal {
+        require(msg.sender == governance() || msg.sender == strategist);
+    }
+
     function _onlyKeepers() internal {
         require(
             msg.sender == keeper ||
@@ -377,7 +381,7 @@ abstract contract BaseStrategy {
      * @param _rewards The address to use for pulling rewards.
      */
     function setRewards(address _rewards) external {
-        _onlyStrategist();
+        _onlyRewarder();
         require(_rewards != address(0));
         vault.approve(rewards, 0);
         rewards = _rewards;

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -75,7 +75,7 @@ def test_strategy_harvest_permission(
 @pytest.mark.parametrize(
     "getter,setter,val,gov_allowed,strategist_allowed",
     [
-        ("rewards", "setRewards", None, False, True),
+        ("rewards", "setRewards", None, True, True),
         ("keeper", "setKeeper", None, True, True),
         ("minReportDelay", "setMinReportDelay", 1000, True, True),
         ("maxReportDelay", "setMaxReportDelay", 2000, True, True),
@@ -133,6 +133,12 @@ def test_set_strategist_authority(strategy, strategist, rando):
     # Now the original strategist shouldn't be able to set strategist again
     with brownie.reverts():
         strategy.setStrategist(rando, {"from": strategist})
+
+
+def test_set_rewards(strategy, rando):
+    # Only gov or strategist can setRewards
+    with brownie.reverts():
+        strategy.setRewards(rando, {"from": rando})
 
 
 def test_strategy_setParams_bad_vals(gov, strategist, strategy):

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -216,6 +216,5 @@ def test_vault_setLockedProfitDegradation_range(gov, vault):
 def test_vault_setParams_bad_vals(gov, vault):
     with brownie.reverts():
         vault.setRewards(ZERO_ADDRESS, {"from": gov})
-
     with brownie.reverts():
         vault.setRewards(vault, {"from": gov})


### PR DESCRIPTION
This is update was requested in [467](https://github.com/yearn/yearn-vaults/issues/467).

The contract BaseStrategy has the onlyRewards updated so that only governance can update the address. The corresponding tests have been updated. 