### PR TITLE
fix: move require isOriginal to main clone function

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -861,7 +861,6 @@ abstract contract BaseStrategyInitializable is BaseStrategy {
     }
 
     function clone(address _vault) external returns (address) {
-        require(isOriginal, "!clone");
         return this.clone(_vault, msg.sender, msg.sender, msg.sender);
     }
 
@@ -871,6 +870,7 @@ abstract contract BaseStrategyInitializable is BaseStrategy {
         address _rewards,
         address _keeper
     ) external returns (address newStrategy) {
+        require(isOriginal, "!clone");
         // Copied from https://github.com/optionality/clone-factory/blob/master/contracts/CloneFactory.sol
         bytes20 addressBytes = bytes20(address(this));
 


### PR DESCRIPTION
## Description

It moves the `require(isOriginal)` statement to the main `clone` function due to any strategist might call it without verifying whether it is the original strategy or not.

Fixes # (issue) NA

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
