### PR TITLE
fix: update token balance to share calculation

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -132,7 +132,7 @@ def increase_pps(CommonHealthCheck, chain):
         vault.setManagementFee(0, {"from": vault.governance()})
         vault.setPerformanceFee(0, {"from": vault.governance()})
         vault.updateStrategyPerformanceFee(strategy, 0, {"from": vault.governance()})
-        strategy.harvest()
+        strategy.harvest({"from": vault.governance()})
         vault.setManagementFee(managementFee, {"from": vault.governance()})
         vault.setPerformanceFee(performanceFee, {"from": vault.governance()})
         chain.sleep(7 * 3600)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -119,8 +119,8 @@ def strategy(gov, strategist, keeper, rewards, vault, TestStrategy, request):
 
 
 @pytest.fixture
-def increase_pps(CommonHealthCheck, strategy, chain):
-    def increase_pps(vault, token, amount, sender):
+def increase_pps(CommonHealthCheck, chain):
+    def increase_pps(vault, strategy, token, amount, sender):
         common_health_check = vault.healthCheck()
         if common_health_check != ZERO_ADDRESS:
             common_health_check = CommonHealthCheck.at(common_health_check)
@@ -129,12 +129,12 @@ def increase_pps(CommonHealthCheck, strategy, chain):
         token.transfer(strategy, amount, {"from": sender})
         managementFee = vault.managementFee()
         performanceFee = vault.performanceFee()
-        vault.setManagementFee(0)
-        vault.setPerformanceFee(0)
-        vault.updateStrategyPerformanceFee(strategy, 0)
+        vault.setManagementFee(0, {"from": vault.governance()})
+        vault.setPerformanceFee(0, {"from": vault.governance()})
+        vault.updateStrategyPerformanceFee(strategy, 0, {"from": vault.governance()})
         strategy.harvest()
-        vault.setManagementFee(managementFee)
-        vault.setPerformanceFee(performanceFee)
+        vault.setManagementFee(managementFee, {"from": vault.governance()})
+        vault.setPerformanceFee(performanceFee, {"from": vault.governance()})
         chain.sleep(7 * 3600)
         chain.mine()
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -119,8 +119,11 @@ def strategy(gov, strategist, keeper, rewards, vault, TestStrategy, request):
 
 
 @pytest.fixture
-def increase_pps(CommonHealthCheck, chain):
-    def increase_pps(vault, strategy, token, amount, sender):
+def increase_pps(Vault, CommonHealthCheck, strategy, chain):
+    default_strategy = strategy
+
+    def increase_pps(vault, token, amount, sender, strategy=default_strategy):
+        governance = vault.governance()
         common_health_check = vault.healthCheck()
         if common_health_check != ZERO_ADDRESS:
             common_health_check = CommonHealthCheck.at(common_health_check)
@@ -129,12 +132,12 @@ def increase_pps(CommonHealthCheck, chain):
         token.transfer(strategy, amount, {"from": sender})
         managementFee = vault.managementFee()
         performanceFee = vault.performanceFee()
-        vault.setManagementFee(0, {"from": vault.governance()})
-        vault.setPerformanceFee(0, {"from": vault.governance()})
-        vault.updateStrategyPerformanceFee(strategy, 0, {"from": vault.governance()})
-        strategy.harvest({"from": vault.governance()})
-        vault.setManagementFee(managementFee, {"from": vault.governance()})
-        vault.setPerformanceFee(performanceFee, {"from": vault.governance()})
+        vault.setManagementFee(0, {"from": governance})
+        vault.setPerformanceFee(0, {"from": governance})
+        vault.updateStrategyPerformanceFee(strategy, 0, {"from": governance})
+        strategy.harvest({"from": governance})
+        vault.setManagementFee(managementFee, {"from": governance})
+        vault.setPerformanceFee(performanceFee, {"from": governance})
         chain.sleep(7 * 3600)
         chain.mine()
 

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -288,10 +288,10 @@ def test_transferFrom(accounts, token, vault):
     assert vault.balanceOf(b) == token.balanceOf(vault)
 
 
-def test_do_not_issue_zero_shares(gov, strategy, token, vault, increase_pps):
+def test_do_not_issue_zero_shares(gov, token, vault, increase_pps):
     token.approve(vault, 500, {"from": gov})
     vault.deposit(500, {"from": gov})
-    strategy = increase_pps(vault, strategy, token, 500, gov)  # inflate price
+    strategy = increase_pps(vault, token, 500, gov)  # inflate price
     assert vault.pricePerShare() == 2 * 10 ** token.decimals()  # 2:1 price
     with brownie.reverts():
         vault.deposit(1, {"from": gov})

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -288,10 +288,10 @@ def test_transferFrom(accounts, token, vault):
     assert vault.balanceOf(b) == token.balanceOf(vault)
 
 
-def test_do_not_issue_zero_shares(gov, token, vault, increase_pps):
+def test_do_not_issue_zero_shares(gov, strategy, token, vault, increase_pps):
     token.approve(vault, 500, {"from": gov})
     vault.deposit(500, {"from": gov})
-    strategy = increase_pps(vault, token, 500, gov)  # inflate price
+    strategy = increase_pps(vault, strategy, token, 500, gov)  # inflate price
     assert vault.pricePerShare() == 2 * 10 ** token.decimals()  # 2:1 price
     with brownie.reverts():
         vault.deposit(1, {"from": gov})

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -174,7 +174,7 @@ def test_progressive_withdrawal(
     # Deposit something in strategies
     chain.sleep(1)  # Needs to be a second ahead, at least
     for s in strategies:
-        increase_pps(vault, s, token, 500, guardian)
+        increase_pps(vault, token, 500, guardian, s)
     assert token.balanceOf(vault) < vault.totalAssets()  # Some debt is in strategies
 
     # Trying to withdraw 0 shares. It should revert
@@ -253,7 +253,7 @@ def test_withdrawal_with_empty_queue(
     chain.sleep(8640)
     common_health_check.setDisabledCheck(strategy, True, {"from": gov})
 
-    increase_pps(vault, strategy, token, 1000, guardian)
+    increase_pps(vault, token, 1000, guardian, strategy)
     assert token.balanceOf(vault) < vault.totalAssets()
 
     vault.removeStrategyFromQueue(strategy, {"from": gov})

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -176,7 +176,7 @@ def test_progressive_withdrawal(
     # First withdraw everything possible without fees
     free_balance = token.balanceOf(vault)
     vault.withdraw(
-        free_balance * vault.pricePerShare() // 10 ** vault.decimals(), {"from": gov}
+        free_balance * (10 ** vault.decimals()) // vault.pricePerShare(), {"from": gov}
     )
     assert token.balanceOf(gov) == free_balance
     assert vault.balanceOf(gov) > 0
@@ -185,7 +185,8 @@ def test_progressive_withdrawal(
     balance_strat1 = token.balanceOf(strategies[0])
     assert balance_strat1 > 0
     vault.withdraw(
-        balance_strat1 * vault.pricePerShare() // 10 ** vault.decimals(), {"from": gov}
+        balance_strat1 * (10 ** vault.decimals()) // vault.pricePerShare(),
+        {"from": gov},
     )
     assert token.balanceOf(gov) == free_balance + balance_strat1
     assert vault.balanceOf(gov) > 0
@@ -195,7 +196,8 @@ def test_progressive_withdrawal(
     balance_strat2 = token.balanceOf(strategies[1])
     assert balance_strat2 > 0
     vault.withdraw(
-        balance_strat2 * vault.pricePerShare() // 10 ** vault.decimals(), {"from": gov}
+        balance_strat2 * (10 ** vault.decimals()) // vault.pricePerShare(),
+        {"from": gov},
     )
     assert token.balanceOf(gov) == free_balance + balance_strat1 + balance_strat2
     assert vault.balanceOf(gov) == 0
@@ -237,19 +239,22 @@ def test_withdrawal_with_empty_queue(
     free_balance = token.balanceOf(vault)
     strategy_balance = token.balanceOf(strategy)
     assert (
-        vault.balanceOf(gov) == 1000 * vault.pricePerShare() // 10 ** vault.decimals()
+        vault.balanceOf(gov) == 1000 * (10 ** vault.decimals()) // vault.pricePerShare()
     )
     vault.withdraw(
-        1000 * vault.pricePerShare() // 10 ** vault.decimals(), {"from": gov}
+        1000 * (10 ** vault.decimals()) // vault.pricePerShare(), {"from": gov}
     )
 
     # This means withdrawal will not revert even when we didn't get the total amount back
-    assert vault.balanceOf(gov) == strategy_balance
+    assert (
+        vault.balanceOf(gov)
+        == strategy_balance * (10 ** vault.decimals()) // vault.pricePerShare()
+    )
     assert token.balanceOf(gov) == free_balance
 
     # Calling it a second time with strategy_balance should be a no-op
     vault.withdraw(
-        strategy_balance * vault.pricePerShare() // 10 ** vault.decimals(),
+        strategy_balance * (10 ** vault.decimals()) // vault.pricePerShare(),
         {"from": gov},
     )
     assert token.balanceOf(gov) == free_balance
@@ -258,7 +263,7 @@ def test_withdrawal_with_empty_queue(
     vault.addStrategyToQueue(strategy, {"from": gov})
 
     vault.withdraw(
-        strategy_balance * vault.pricePerShare() // 10 ** vault.decimals(),
+        strategy_balance * (10 ** vault.decimals()) // vault.pricePerShare(),
         {"from": gov},
     )
     assert token.balanceOf(gov) == free_balance + strategy_balance


### PR DESCRIPTION
## Description

Fix the way, the number of shares are calculated from token balance. 

In various places at [test_withdrawal.py](https://github.com/yearn/yearn-vaults/blob/main/tests/functional/vault/test_withdrawal.py#L179), the token balance is converted to vault shares via: `token_balance * vault.pricePerShare() // 10 ** vault.decimals()`.

This seems incorrect as we're multiplying `token_balance` with number of tokens each share represents.

The correct calculation should be: `token_balance // vault.pricePerShare() * (10 ** vault.decimals())`.

The test still passes because in all these cases `vault.pricePerShare() // 10 ** vault.decimals()` turns out to be `1`.

Fixes https://github.com/yearn/yearn-vaults/issues/515

## Checklist

- [ ] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
