### PR TITLE
fix: assert shares amount before withdrawing

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1146,6 +1146,8 @@ def withdraw(
         #       withdrawing are more than what is considered acceptable.
         assert totalLoss <= maxLoss * (value + totalLoss) / MAX_BPS
 
+    assert shares <= maxShares
+
     # Burn shares (full value of what is being withdrawn)
     self.totalSupply -= shares
     self.balanceOf[msg.sender] -= shares

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1141,12 +1141,14 @@ def withdraw(
             # NOTE: Burn # of shares that corresponds to what Vault has on-hand,
             #       including the losses that were incurred above during withdrawals
             shares = self._sharesForAmount(value + totalLoss)
+            # NOTE: Check current shares must be lower than maxShare.
+            #       This implies that large withdrawals within certain parameter ranges might fail.
+            assert shares <= maxShares
 
         # NOTE: This loss protection is put in place to revert if losses from
         #       withdrawing are more than what is considered acceptable.
         assert totalLoss <= maxLoss * (value + totalLoss) / MAX_BPS
 
-    assert shares <= maxShares
 
     # Burn shares (full value of what is being withdrawn)
     self.totalSupply -= shares

--- a/contracts/test/SimpleStrategy.sol
+++ b/contracts/test/SimpleStrategy.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.12;
+
+import {Math} from "@openzeppelin/contracts/math/Math.sol";
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import {VaultAPI} from "../BaseStrategy.sol";
+
+interface IStrategy {
+    function want() external view returns (address);
+
+    function vault() external view returns (address);
+
+    function delegatedAssets() external view returns (uint256);
+
+    function withdraw(uint256 _amount) external returns (uint256 loss);
+}
+
+contract SimpleStrategy is IStrategy {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    address public immutable override want;
+    address public immutable override vault;
+    uint256 public constant override delegatedAssets = 0;
+    uint256 public totalDebt;
+    uint256 public nextWidthdraw;
+    uint256 public nextLoss;
+
+    constructor(address _want, address _vault) public {
+        want = _want;
+        vault = _vault;
+        IERC20(_want).safeApprove(_vault, type(uint256).max);
+    }
+
+    function setNext(uint256 _nextWithdraw, uint256 _nextLoss) external {
+        nextWidthdraw = _nextWithdraw;
+        nextLoss = _nextLoss;
+    }
+
+    function withdraw(uint256) external override returns (uint256 loss) {
+        loss = nextLoss;
+        _withdraw(nextWidthdraw, loss);
+    }
+
+    function initialReport() external {
+        _report(0, 0, 0);
+    }
+
+    function _withdraw(uint256 _withdrawAmount, uint256 _loss) internal {
+        totalDebt = totalDebt.sub(_withdrawAmount).sub(_loss);
+        IERC20(want).transfer(vault, _withdrawAmount);
+    }
+
+    function _reserves() internal view returns (uint256) {
+        return IERC20(want).balanceOf(address(this));
+    }
+
+    function _report(
+        uint256 _gain,
+        uint256 _loss,
+        uint256 _debtPayment
+    ) internal {
+        uint256 newTotalDebt = totalDebt.sub(_loss);
+        uint256 balanceBefore = _reserves();
+        uint256 debtPayment = Math.min(_debtPayment, VaultAPI(vault).debtOutstanding());
+        VaultAPI(vault).report(_gain, _loss, debtPayment);
+        uint256 balanceAfter = _reserves();
+        totalDebt = newTotalDebt.add(balanceAfter).sub(balanceBefore);
+    }
+}

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -150,6 +150,7 @@ def rando(accounts):
 def registry(gov, Registry):
     yield gov.deploy(Registry)
 
+
 @pytest.fixture
 def simpleStrategy(strategist, token, vault, SimpleStrategy):
     strategy = strategist.deploy(SimpleStrategy, token, vault)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -149,3 +149,8 @@ def rando(accounts):
 @pytest.fixture
 def registry(gov, Registry):
     yield gov.deploy(Registry)
+
+@pytest.fixture
+def simpleStrategy(strategist, token, vault, SimpleStrategy):
+    strategy = strategist.deploy(SimpleStrategy, token, vault)
+    yield strategy

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -1,6 +1,7 @@
 import pytest
 import brownie
-
+from brownie import ZERO_ADDRESS
+from contextlib import contextmanager
 
 @pytest.fixture
 def vault(gov, token, Vault):
@@ -12,6 +13,21 @@ def vault(gov, token, Vault):
     vault.setDepositLimit(2**256 - 1, {"from": gov})
     yield vault
 
+@contextmanager
+def expect_balance_change(
+        token, account, increase,
+        error_message='Balance did not have expected change'
+):
+    balance_before = token.balanceOf(account)
+    try:
+        yield
+    finally:
+        balance_after = token.balanceOf(account)
+        real_increase = balance_after - balance_before
+        assert real_increase == increase, error_message
+
+def to_full_token(amount, decimals = 18):
+    return int(amount * 10**decimals)
 
 def test_deposit_with_zero_funds(vault, token, rando):
     assert token.balanceOf(rando) == 0
@@ -276,3 +292,55 @@ def test_do_not_issue_zero_shares(gov, token, vault, increase_pps):
     assert vault.pricePerShare() == 2 * 10 ** token.decimals()  # 2:1 price
     with brownie.reverts():
         vault.deposit(1, {"from": gov})
+
+def test_deposit_withdraw_whale(gov, vault, token, simpleStrategy, accounts):
+    main_user = accounts[5];
+
+    total_balance = token.balanceOf(gov)
+    token.transfer(main_user, total_balance, {'from': gov})
+
+    strategy_share = 8_000
+    vault.addStrategy(simpleStrategy, strategy_share, 0, 2**256 - 1, 0)
+    vault.setDepositLimit(2**256-1)
+    # confirm only a single strategy in queue
+    assert vault.withdrawalQueue(0) == simpleStrategy.address
+    assert vault.withdrawalQueue(1) == ZERO_ADDRESS
+    
+    token.approve(vault,  2**256 - 1, {'from': main_user})
+
+    with expect_balance_change(vault, main_user, total_balance):
+        vault.deposit({'from': main_user})
+    
+    strategy_share = total_balance * strategy_share / 10_000
+    with expect_balance_change(token, simpleStrategy, strategy_share):
+        simpleStrategy.initialReport()
+
+    total_debt = simpleStrategy.totalDebt()
+    assert total_debt == strategy_share
+    
+    tokenDecimals = token.decimals()
+    vaultDecimals = vault.decimals()
+    vault_reserves = token.balanceOf(vault)
+    
+    shares_before = vault.balanceOf(main_user)
+    max_shares = to_full_token((vault_reserves / to_full_token(1, tokenDecimals)) + 20, vaultDecimals)  # 20 tokens above vault reserves
+    max_value_handicap = max_shares - vault_reserves - 1
+
+    assert shares_before >= max_shares, 'insufficient shares'
+
+    # tiny loss (10 wei) used as example larger losses lead to more additional shares burnt
+    loss = 10
+    # sets next withdrawal and loss amount in dummy strategy to simplify PoC
+    simpleStrategy.setNext(max_value_handicap - loss, loss)
+    max_loss = 1  # 0.01%
+
+    with brownie.reverts():
+        tx = vault.withdraw(max_shares, main_user,
+                        max_loss, {'from': main_user})
+    
+    shares_after = vault.balanceOf(main_user)
+    shares_burnt = shares_before - shares_after
+
+    assert shares_burnt <= max_shares, 'More shares burnt than allowed'
+    assert shares_burnt == 0, 'Shares burnt must be zero'
+    assert shares_after == to_full_token(30000, tokenDecimals), 'Shares after withdrawing must be the same as initial'

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -3,6 +3,7 @@ import brownie
 from brownie import ZERO_ADDRESS
 from contextlib import contextmanager
 
+
 @pytest.fixture
 def vault(gov, token, Vault):
     # NOTE: Overriding the one in conftest because it has values already
@@ -13,10 +14,10 @@ def vault(gov, token, Vault):
     vault.setDepositLimit(2**256 - 1, {"from": gov})
     yield vault
 
+
 @contextmanager
 def expect_balance_change(
-        token, account, increase,
-        error_message='Balance did not have expected change'
+    token, account, increase, error_message="Balance did not have expected change"
 ):
     balance_before = token.balanceOf(account)
     try:
@@ -26,8 +27,10 @@ def expect_balance_change(
         real_increase = balance_after - balance_before
         assert real_increase == increase, error_message
 
-def to_full_token(amount, decimals = 18):
-    return int(amount * 10**decimals)
+
+def to_full_token(amount, decimals=18):
+    return int(amount * 10 ** decimals)
+
 
 def test_deposit_with_zero_funds(vault, token, rando):
     assert token.balanceOf(rando) == 0
@@ -293,40 +296,43 @@ def test_do_not_issue_zero_shares(gov, token, vault, increase_pps):
     with brownie.reverts():
         vault.deposit(1, {"from": gov})
 
+
 def test_deposit_withdraw_whale(gov, vault, token, simpleStrategy, accounts):
-    main_user = accounts[5];
+    main_user = accounts[5]
 
     total_balance = token.balanceOf(gov)
-    token.transfer(main_user, total_balance, {'from': gov})
+    token.transfer(main_user, total_balance, {"from": gov})
 
     strategy_share = 8_000
-    vault.addStrategy(simpleStrategy, strategy_share, 0, 2**256 - 1, 0)
-    vault.setDepositLimit(2**256-1)
+    vault.addStrategy(simpleStrategy, strategy_share, 0, 2 ** 256 - 1, 0)
+    vault.setDepositLimit(2 ** 256 - 1)
     # confirm only a single strategy in queue
     assert vault.withdrawalQueue(0) == simpleStrategy.address
     assert vault.withdrawalQueue(1) == ZERO_ADDRESS
-    
-    token.approve(vault,  2**256 - 1, {'from': main_user})
+
+    token.approve(vault, 2 ** 256 - 1, {"from": main_user})
 
     with expect_balance_change(vault, main_user, total_balance):
-        vault.deposit({'from': main_user})
-    
+        vault.deposit({"from": main_user})
+
     strategy_share = total_balance * strategy_share / 10_000
     with expect_balance_change(token, simpleStrategy, strategy_share):
         simpleStrategy.initialReport()
 
     total_debt = simpleStrategy.totalDebt()
     assert total_debt == strategy_share
-    
+
     tokenDecimals = token.decimals()
     vaultDecimals = vault.decimals()
     vault_reserves = token.balanceOf(vault)
-    
+
     shares_before = vault.balanceOf(main_user)
-    max_shares = to_full_token((vault_reserves / to_full_token(1, tokenDecimals)) + 20, vaultDecimals)  # 20 tokens above vault reserves
+    max_shares = to_full_token(
+        (vault_reserves / to_full_token(1, tokenDecimals)) + 20, vaultDecimals
+    )  # 20 tokens above vault reserves
     max_value_handicap = max_shares - vault_reserves - 1
 
-    assert shares_before >= max_shares, 'insufficient shares'
+    assert shares_before >= max_shares, "insufficient shares"
 
     # tiny loss (10 wei) used as example larger losses lead to more additional shares burnt
     loss = 10
@@ -335,12 +341,13 @@ def test_deposit_withdraw_whale(gov, vault, token, simpleStrategy, accounts):
     max_loss = 1  # 0.01%
 
     with brownie.reverts():
-        tx = vault.withdraw(max_shares, main_user,
-                        max_loss, {'from': main_user})
-    
+        tx = vault.withdraw(max_shares, main_user, max_loss, {"from": main_user})
+
     shares_after = vault.balanceOf(main_user)
     shares_burnt = shares_before - shares_after
 
-    assert shares_burnt <= max_shares, 'More shares burnt than allowed'
-    assert shares_burnt == 0, 'Shares burnt must be zero'
-    assert shares_after == to_full_token(30000, tokenDecimals), 'Shares after withdrawing must be the same as initial'
+    assert shares_burnt <= max_shares, "More shares burnt than allowed"
+    assert shares_burnt == 0, "Shares burnt must be zero"
+    assert shares_after == to_full_token(
+        30000, tokenDecimals
+    ), "Shares after withdrawing must be the same as initial"

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -29,7 +29,7 @@ def expect_balance_change(
 
 
 def to_full_token(amount, decimals=18):
-    return int(amount * 10 ** decimals)
+    return int(amount * 10**decimals)
 
 
 def test_deposit_with_zero_funds(vault, token, rando):
@@ -304,13 +304,13 @@ def test_deposit_withdraw_whale(gov, vault, token, simpleStrategy, accounts):
     token.transfer(main_user, total_balance, {"from": gov})
 
     strategy_share = 8_000
-    vault.addStrategy(simpleStrategy, strategy_share, 0, 2 ** 256 - 1, 0)
-    vault.setDepositLimit(2 ** 256 - 1)
+    vault.addStrategy(simpleStrategy, strategy_share, 0, 2**256 - 1, 0)
+    vault.setDepositLimit(2**256 - 1)
     # confirm only a single strategy in queue
     assert vault.withdrawalQueue(0) == simpleStrategy.address
     assert vault.withdrawalQueue(1) == ZERO_ADDRESS
 
-    token.approve(vault, 2 ** 256 - 1, {"from": main_user})
+    token.approve(vault, 2**256 - 1, {"from": main_user})
 
     with expect_balance_change(vault, main_user, total_balance):
         vault.deposit({"from": main_user})


### PR DESCRIPTION
## Description

When withdrawing using a vault's withdraw method the vault will withdraw from strategies in the withdrawal queue if the vault's token balance doesn't directly cover the calculated withdrawal value. Furthermore if depleting the strategies still doesn't cover the necessary withdrawal amount after deducting strategy losses the vault will recalculate the share amount to be burnt.

Fixes # (bug reported in immunefi)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
