### PR TITLE
fix: test CI typo

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
     - name: Compile Code
       run: brownie compile --size
 
-    - name: Run Splitted Tests
+    - name: Run Split Tests
       if: steps.check_test_durations.outputs.files_exists == 'true' 
       run: brownie test tests/functional --gas --coverage --splits 6 --group ${{ matrix.group }};
 


### PR DESCRIPTION
## Description

Fixed a small typo in the test CI

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
