### PR TITLE
docs: Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yearn Vault Contracts
 
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/yearn/yearn-vaults/badge)](https://www.gitpoap.io/gh/yearn/yearn-vaults)
+
 Please read and be familiar with the [Specification](SPECIFICATION.md).
 
 This repository is the set of smart contracts that are used for the Yearn Vaults.


### PR DESCRIPTION
## Description

Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
