### PR TITLE
docs: set correct devdocs link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Docs have been migrated
 
-This folder has been migrated to [yearn-devdocs](https://github.com/yearn/yearn-devdocs/tree/master/docs/v2)
+This folder has been migrated to [yearn-devdocs](https://github.com/yearn/yearn-devdocs/tree/master/docs)


### PR DESCRIPTION
Set the correct link to yearn-devdocs repo. Maybe it would make more sense to remove `docs` folder.
