### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,7 +90,7 @@ jobs:
     - name: Compile Code
       run: brownie compile --size
 
-    - name: Run Splitted Tests
+    - name: Run Split Tests
       if: steps.check_test_durations.outputs.files_exists == 'true' 
       run: brownie test tests/functional --gas --coverage --splits 6 --group ${{ matrix.group }};
 

--- a/contracts/BaseFeeOracle.sol
+++ b/contracts/BaseFeeOracle.sol
@@ -7,7 +7,7 @@ interface IBaseFee {
 
 /**
  * @dev Interprets the base fee from our base fee provider
- *  contract to determine if a harvest is permissable.
+ *  contract to determine if a harvest is permissible.
  *
  * Version 0.1.0
  */

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def arg_types(args):
         args = args[0]["components"]
 
     # NOTE: Need to filter out `name` and `internalType`,
-    #       it isn't useful and hurts our comparisions
+    #       it isn't useful and hurts our comparisons
     return [
         {k: v for k, v in arg.items() if k not in ("internalType", "name")}
         for arg in args


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `.github/workflows/test.yaml`
- 1 typo in `contracts/BaseFeeOracle.sol`
- 1 typo in `tests/conftest.py`



Best! :robot: