### PR TITLE
Update BaseFeeOracle.sol: Reduction of extra Slot

### DIFF
--- a/contracts/BaseFeeOracle.sol
+++ b/contracts/BaseFeeOracle.sol
@@ -7,7 +7,7 @@ interface IBaseFee {
 
 /**
  * @dev Interprets the base fee from our base fee provider
- *  contract to determine if a harvest is permissable.
+ *  contract to determine if a harvest is permissible.
  *
  * Version 0.1.0
  */
@@ -18,9 +18,10 @@ contract BaseFeeOracle {
 
     address public governance; /// @notice Governance can grant and revoke access to the setter
     address public pendingGovernance; /// @notice New address must be set by current gov and then accept to transfer power.
+    bool public manualBaseFeeBool; /// @notice Use this if our network hasn't implemented the base fee method yet
+
     mapping(address => bool) public authorizedAddresses; /// @notice Addresses that can set the max acceptable base fee
 
-    bool public manualBaseFeeBool; /// @notice Use this if our network hasn't implemented the base fee method yet
 
     constructor() {
         governance = msg.sender; // our deployer should be gov, they can set up the rest


### PR DESCRIPTION
In the current file, state variables were arranged in this form:

```
address public baseFeeProvider; // slot 1
uint256 public maxAcceptableBaseFee; // slot 2

address public governance; // slot 3
address public pendingGovernance; // slot 4
mapping(address => bool) public authorizedAddresses; // slot 5 - slot_hash, values are stored at keccak256(key, slot)

bool public manualBaseFeeBool; // slot 6

// Total 6 slots are used up if we don't count the values in mapping
```

After the changes:

```
address public baseFeeProvider; // slot 1
uint256 public maxAcceptableBaseFee; // slot 2

address public governance; // slot 3
address public pendingGovernance; // slot 4
bool public manualBaseFeeBool; // slot 4

mapping(address => bool) public authorizedAddresses; // slot 5 - slot_hash, values are stored at keccak256(key, slot)

// Total 5 slots are used up if we don't count the values in mapping
```

With this one slot got reduced, cuz each slot can take upto 32 bytes whereas address covers up 20 bytes of space and bool takes up 1 byte. Thus, they both will be assigned into 1 slot i.e slot 4

For Further Explaination: [link](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#pack-structs-in-solidity)

Although, there was one more doubt related to `bool public manualBaseFeeBool;`, this variable will always be set to true in the constructor itself..Then why we don't just remove `manualBaseFeeBool = true;` from the constructor and change the initialization to `bool public manualBaseFeeBool = true;`. Why to add an extra line of code?

Thanks!